### PR TITLE
[SNOW-43] Fix permissions for data engineer role

### DIFF
--- a/admin/grants.sql
+++ b/admin/grants.sql
@@ -10,7 +10,8 @@ GRANT ROLE SYSADMIN
 TO USER "kevin.boske@sagebase.org";
 GRANT ROLE SYSADMIN
 TO USER "x.schildwachter@sagebase.org";
-
+GRANT ROLE SYSADMIN
+TO USER DPE_SERVICE;
 -- warehouse usage privileges
 GRANT USAGE ON WAREHOUSE COMPUTE_XSMALL
 TO ROLE DATA_ANALYTICS;


### PR DESCRIPTION
**Problem**

`ALTER` and `DROP` table actions require ownership of the table.  Most created tables right now are by the SYSADMIN role.

**Solution**

Grant the DPE_service user access to the SYSADMIN role.  Eventually we will want to do an overall permissions scrub or transfer everything in snowflake to the DATA_ENGINEER role to keep things clean.