### PR TITLE
[SYNSD-893] Add query for disjointed name

### DIFF
--- a/analytics/find_disjointed_file_name_to_download_name.sql
+++ b/analytics/find_disjointed_file_name_to_download_name.sql
@@ -1,0 +1,15 @@
+-- This was a small query put together for https://sagebionetworks.jira.com/browse/SYNSD-893
+-- The query is looking for files that have a different name than the entity they are associated with
+USE ROLE DATA_ENGINEER;
+USE WAREHOUSE COMPUTE_XSMALL;
+USE DATABASE SYNAPSE_DATA_WAREHOUSE;
+USE SCHEMA SYNAPSE;
+
+-- This is looking by parent_ID
+SELECT ENTITY_LATEST.id, ENTITY_LATEST.name, FILE_LATEST.FILE_NAME, FILE_LATEST.CONTENT_MD5 FROM synapse_data_warehouse.synapse.node_latest ENTITY_LATEST
+inner join
+    synapse_data_warehouse.synapse.file_latest FILE_LATEST
+on
+    ENTITY_LATEST.file_handle_id = FILE_LATEST.ID
+WHERE ENTITY_LATEST.PARENT_ID = 51286684
+AND FILE_LATEST.FILE_NAME != ENTITY_LATEST.name


### PR DESCRIPTION
**Problem:**
- Synapse allows an entity name to be disjointed from the name of the file. This can lead to some problems when the downloadAs name (The name of the file) overlaps with other files in the folder - and when the name of the FileEntity appears to be correct.

**Solution:**
- Adding in a small query I used to identify which Files in a specific folder had a DownloadAs name which did not match the name of the entity. We had used this to pass along information over to the collaborator to resolve the issue.

I also added a small script via this commit to the examples section that contains how to update all files in a folder to match the downloadAs to the name of the entity: https://github.com/Sage-Bionetworks/synapsePythonClient/commit/ed00ef506e5d5334c21728e4533e57a52124bd3e