### PR TITLE
[SNOW-33] New ingest to projectsettingsnapshots table

### DIFF
--- a/synapse_data_warehouse/synapse_raw/tables/V2.20.0__ingest_into_projectsettingsnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.20.0__ingest_into_projectsettingsnapshots.sql
@@ -1,0 +1,30 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+USE WAREHOUSE COMPUTE_MEDIUM;
+
+COPY INTO
+    ACCESSREQUIREMENTSNAPSHOTS
+FROM (
+SELECT
+    $1:change_timestamp as change_timestamp,
+    $1:change_type as change_type,
+    $1:change_user_id as change_user_id,
+    $1:snapshot_timestamp as snapshot_timestamp,
+    $1:id as id,
+    $1:concrete_type as concrete_type,
+    $1:project_id as project_id,
+    $1:settings_type as settings_type,
+    $1:etag as etag,
+    $1:locations as locations
+    NULLIF(
+                    regexp_replace(
+                        METADATA$FILENAME,
+                        '.*projectsettingsnapshots\/snapshot_date\=(.*)\/.*',
+                        '\\1'),
+                    '__HIVE_DEFAULT_PARTITION__'
+                ) as snapshot_date
+            from
+                @{{stage_storage_integration}}_stage/projectsettingsnapshots --noqa: TMP
+            )
+pattern='.*projectsettingsnapshots/snapshot_date=.*/.*'
+FORCE=TRUE
+;

--- a/synapse_data_warehouse/synapse_raw/tables/V2.20.0__ingest_into_projectsettingsnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.20.0__ingest_into_projectsettingsnapshots.sql
@@ -14,7 +14,7 @@ SELECT
     $1:project_id as project_id,
     $1:settings_type as settings_type,
     $1:etag as etag,
-    $1:locations as locations
+    $1:locations as locations,
     NULLIF(
                     regexp_replace(
                         METADATA$FILENAME,

--- a/synapse_data_warehouse/synapse_raw/tables/V2.20.0__ingest_into_projectsettingsnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.20.0__ingest_into_projectsettingsnapshots.sql
@@ -2,7 +2,7 @@ USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
 USE WAREHOUSE COMPUTE_MEDIUM;
 
 COPY INTO
-    ACCESSREQUIREMENTSNAPSHOTS
+    PROJECTSETTINGSNAPSHOTS
 FROM (
 SELECT
     $1:change_timestamp as change_timestamp,


### PR DESCRIPTION
This branch introduces an ingest script used to copy new data from staging into `projectsettingsnapshots`

## testing & preview

testing the script on a test db ( some information is redacted for security ):

<img width="855" alt="image" src="https://github.com/Sage-Bionetworks/snowflake/assets/32107699/80963c46-20f5-4f2e-ab6c-eaf9c30df56f">

the files show up as expected in the table within my test db:

<img width="460" alt="image" src="https://github.com/Sage-Bionetworks/snowflake/assets/32107699/c433fa71-68d9-4397-894b-8cf27b969494">
