### PR TITLE
[SNOW-33] reintroduce projectsettingsnapshots task

### DIFF
--- a/synapse_data_warehouse/synapse_raw/tables/R__create_projectsettingsnapshots_table.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/R__create_projectsettingsnapshots_table.sql
@@ -10,6 +10,7 @@ CREATE OR ALTER TABLE PROJECTSETTINGSNAPSHOTS (
     PROJECT_ID NUMBER(38,0) COMMENT 'The ID of the project to which the settings apply.',
     SETTINGS_TYPE VARCHAR(16777216) COMMENT 'The short type of the project settings. See https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/ProjectSettings.html.',
     ETAG VARCHAR(16777216) COMMENT 'UUID issued each time the project settings changes.',
+    LOCATIONS ARRAY COMMENT 'The storage location IDs associated with the project setting.',
     SNAPSHOT_DATE DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.'
 )
 CLUSTER BY (SNAPSHOT_DATE)

--- a/synapse_data_warehouse/synapse_raw/tables/R__projectsettingsnapshots_append_task.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/R__projectsettingsnapshots_append_task.sql
@@ -1,0 +1,35 @@
+use role accountadmin;
+use schema {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+alter task refresh_synapse_warehouse_s3_stage_task suspend;
+create task if not exists append_to_projectsettingsnapshots_task
+    user_task_managed_initial_warehouse_size = 'SMALL'
+    AFTER refresh_synapse_warehouse_s3_stage_task
+as
+    copy into
+        projectsettingsnapshots
+    from (
+        select
+            $1:change_timestamp as change_timestamp,
+            $1:change_type as change_type,
+            $1:change_user_id as change_user_id,
+            $1:snapshot_timestamp as snapshot_timestamp,
+            $1:id as id,
+            $1:concrete_type as concrete_type,
+            $1:project_id as project_id,
+            $1:settings_type as settings_type,
+            $1:etag as etag,
+            $1:locations as locations,
+            NULLIF(
+                regexp_replace(
+                    METADATA$FILENAME,
+                    '.*projectsettingsnapshots\/snapshot_date\=(.*)\/.*',
+                    '\\1'),
+                '__HIVE_DEFAULT_PARTITION__'
+            ) as snapshot_date
+        from
+            @{{stage_storage_integration}}_stage/projectsettingsnapshots --noqa: TMP
+        )
+    pattern='.*projectsettingsnapshots/snapshot_date=.*/.*';
+alter task append_to_projectsettingsnapshots_task resume;
+alter task refresh_synapse_warehouse_s3_stage_task resume;

--- a/synapse_data_warehouse/synapse_raw/tables/R__projectsettingsnapshots_append_task.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/R__projectsettingsnapshots_append_task.sql
@@ -1,4 +1,3 @@
-use role accountadmin;
 use schema {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
 
 alter task refresh_synapse_warehouse_s3_stage_task suspend;


### PR DESCRIPTION
Re-introducing the `projectsettingsnapshots` task script now that builds are working.

Tested the re-introduction of `LOCATIONS` column with dtype `ARRAY` on a test db (commit: https://github.com/Sage-Bionetworks/snowflake/pull/66/commits/1a860e7a1b22275a4e6de798d17ea877e248a9d8)

<img width="992" alt="image" src="https://github.com/Sage-Bionetworks/snowflake/assets/32107699/c5b3b68c-6d25-4f4a-9ee9-b4e2eb87d1e7">
