### PR TITLE
Create authentication policies

### DIFF
--- a/admin/policies.sql
+++ b/admin/policies.sql
@@ -14,6 +14,12 @@
 --     ELSE '*****'
 --   END;
 
+USE ROLE SYSADMIN;
+-- Add all policies into policy_db in case other database is blown away
+CREATE DATABASE IF NOT EXISTS POLICY_DB;
+USE DATABASE POLICY_DB;
+USE ROLE ACCOUNTADMIN;
+
 CREATE PASSWORD POLICY password_policy
 PASSWORD_MIN_LENGTH = 14
 PASSWORD_MAX_AGE_DAYS = 0;
@@ -24,17 +30,50 @@ CREATE SESSION POLICY admin_timeout_policy
 SESSION_IDLE_TIMEOUT_MINS = 15,
 SESSION_UI_IDLE_TIMEOUT_MINS = 15;
 
-ALTER USER x.schildwachter@sagebase.org
+ALTER USER "x.schildwachter@sagebase.org"
 SET SESSION POLICY admin_timeout_policy;
-ALTER USER khai.do@sagebase.org
+ALTER USER "khai.do@sagebase.org"
 SET SESSION POLICY admin_timeout_policy;
 ALTER USER THOMASYU888
 SET SESSION POLICY admin_timeout_policy;
-ALTER USER thomas.yu@sagebase.org
+ALTER USER "thomas.yu@sagebase.org"
 SET SESSION POLICY admin_timeout_policy;
-CREATE TAG ACCOUNT_TYPE;
 
+-- tag service accounts with account type service to not trigger security warning
+CREATE TAG ACCOUNT_TYPE;
 ALTER USER AD_SERVICE SET TAG ACCOUNT_TYPE = 'service';
 ALTER USER DPE_SERVICE SET TAG ACCOUNT_TYPE = 'service';
 ALTER USER SNOWFLAKE SET TAG ACCOUNT_TYPE = 'service';
 ALTER USER thomasyu888 SET TAG ACCOUNT_TYPE = 'service';
+
+-- Set up authentication policies
+-- SHOW PARAMETERS LIKE 'ENABLE_IDENTIFIER_FIRST_LOGIN' IN ACCOUNT;
+ALTER ACCOUNT SET ENABLE_IDENTIFIER_FIRST_LOGIN = TRUE;
+
+-- SHOW PASSWORD POLICIES IN ACCOUNT;
+-- SHOW SESSION POLICIES IN ACCOUNT;
+-- SHOW AUTHENTICATION POLICIES IN ACCOUNT;
+-- SHOW MASKING POLICIES IN ACCOUNT;
+-- SHOW NETWORK RULES IN ACCOUNT;
+
+-- Not including CLIENT_TYPES will enable all types for each auth policy
+CREATE AUTHENTICATION POLICY IF NOT EXISTS service_account_authentication_policy
+  AUTHENTICATION_METHODS = ('PASSWORD');
+
+CREATE AUTHENTICATION POLICY IF NOT EXISTS admin_authentication_policy
+  AUTHENTICATION_METHODS = ('SAML', 'PASSWORD')
+  SECURITY_INTEGRATIONS = ('GOOGLE_SSO', 'JUMPCLOUD');
+
+CREATE AUTHENTICATION POLICY IF NOT EXISTS user_authentication_policy
+  AUTHENTICATION_METHODS = ('SAML')
+  // CLIENT_TYPES = ('SNOWFLAKE_UI', 'SNOWSQL', 'DRIVERS')
+  SECURITY_INTEGRATIONS = ('GOOGLE_SSO');
+
+ALTER ACCOUNT SET AUTHENTICATION POLICY user_authentication_policy;
+ALTER USER "thomas.yu@sagebase.org" SET AUTHENTICATION POLICY admin_authentication_policy;
+ALTER USER "khai.do@sagebase.org" SET AUTHENTICATION POLICY admin_authentication_policy;
+
+ALTER USER RECOVER_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
+ALTER USER DPE_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
+ALTER USER AD_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
+ALTER USER THOMASYU888 SET AUTHENTICATION POLICY service_account_authentication_policy;


### PR DESCRIPTION
## Problem
After adding jumpcloud and supporting multiple IDPs there was an awkward login period for snowflake

## Solution
This avoids that by setting a `user_authentication_policy` on the account level with the opportunity to set specific user authentication policies for those that may want to test the jumpcloud login

Bonus: move most policies into the POLICY_DB so that policies don't get dropped on accident.

Note: these were run manually because there is currently no CI/CD to run auth policies