### PR TITLE
[SNOW-29] New dynamic table: `verificationsubmission_latest`

### DIFF
--- a/synapse_data_warehouse/synapse/dynamic_tables/R__populate_verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/R__populate_verificationsubmission_latest.sql
@@ -1,36 +1,38 @@
 use schema {{database_name}}.synapse; --noqa: JJ01,PRS,TMP,CP01
 
 CREATE OR REPLACE DYNAMIC TABLE {{database_name}}.synapse.verificationsubmission_latest
-AS
-WITH latest_rows AS (
+    TARGET_LAG = '1 day'
+    WAREHOUSE = compute_xsmall
+    AS
+    WITH latest_rows AS (
+        SELECT
+            verificationsubmissionsnapshots.id AS the_id,
+            MAX(snapshot_timestamp) AS latest_timestamp
+        FROM
+            verificationsubmissionsnapshots
+        GROUP BY
+            verificationsubmissionsnapshots.id
+    ),
+    latest_unique_rows AS (
+        SELECT
+            verificationsubmissionsnapshots.*,
+            ROW_NUMBER() OVER (
+                PARTITION BY snapshot_timestamp
+                ORDER BY snapshot_timestamp DESC
+            ) AS row_num
+        FROM
+            verificationsubmissionsnapshots
+        JOIN
+            latest_rows
+        ON
+            verificationsubmissionsnapshots.id = latest_rows.the_id
+            AND verificationsubmissionsnapshots.snapshot_timestamp = latest_rows.latest_timestamp
+    )
     SELECT
-        verificationsubmissionsnapshots.id AS the_id,
-        MAX(snapshot_timestamp) AS latest_timestamp
+        *
     FROM
-        verificationsubmissionsnapshots
-    GROUP BY
-        verificationsubmissionsnapshots.id
-),
-latest_unique_rows AS (
-    SELECT
-        verificationsubmissionsnapshots.*,
-        ROW_NUMBER() OVER (
-            PARTITION BY snapshot_timestamp
-            ORDER BY snapshot_timestamp DESC
-        ) AS row_num
-    FROM
-        verificationsubmissionsnapshots
-    JOIN
-        latest_rows
-    ON
-        verificationsubmissionsnapshots.id = latest_rows.the_id
-        AND verificationsubmissionsnapshots.snapshot_timestamp = latest_rows.latest_timestamp
-)
-SELECT
-    *
-FROM
-    latest_unique_rows
-WHERE
-    row_num = 1
-ORDER BY
-    latest_unique_rows.id;
+        latest_unique_rows
+    WHERE
+        row_num = 1
+    ORDER BY
+        latest_unique_rows.id;

--- a/synapse_data_warehouse/synapse/dynamic_tables/R__populate_verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/R__populate_verificationsubmission_latest.sql
@@ -1,0 +1,36 @@
+use schema {{database_name}}.synapse; --noqa: JJ01,PRS,TMP,CP01
+
+CREATE OR REPLACE DYNAMIC TABLE {{database_name}}.synapse.verificationsubmission_latest
+AS
+WITH latest_rows AS (
+    SELECT
+        verificationsubmissionsnapshots.id AS the_id,
+        MAX(snapshot_timestamp) AS latest_timestamp
+    FROM
+        verificationsubmissionsnapshots
+    GROUP BY
+        verificationsubmissionsnapshots.id
+),
+latest_unique_rows AS (
+    SELECT
+        verificationsubmissionsnapshots.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY snapshot_timestamp
+            ORDER BY snapshot_timestamp DESC
+        ) AS row_num
+    FROM
+        verificationsubmissionsnapshots
+    JOIN
+        latest_rows
+    ON
+        verificationsubmissionsnapshots.id = latest_rows.the_id
+        AND verificationsubmissionsnapshots.snapshot_timestamp = latest_rows.latest_timestamp
+)
+SELECT
+    *
+FROM
+    latest_unique_rows
+WHERE
+    row_num = 1
+ORDER BY
+    latest_unique_rows.id;


### PR DESCRIPTION
## problem

The latest table for `verificationsubmissionsnapshots` does not exist in Snowflake.

Associated with #83

## solution

Introduce a new R script that updates a dynamic table showing the latest version of `verificationsubmissionsnapshots`

## testing

See #83