### PR TITLE
[SNOW-27] add version script to populate usergroup_latest table

### DIFF
--- a/synapse_data_warehouse/synapse/dynamic_tables/R__populate_usergroup_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/R__populate_usergroup_latest.sql
@@ -1,0 +1,21 @@
+use schema {{database_name}}.synapse; --noqa: JJ01,PRS,TMP,CP01
+
+CREATE OR REPLACE DYNAMIC TABLE USERGROUP_LATEST
+    TARGET_LAG = DOWNSTREAM
+    WAREHOUSE = compute_xsmall
+    AS
+        WITH dedup_usergroup AS (
+            SELECT
+                *,
+                "row_number"()
+                    OVER (
+                        PARTITION BY ID
+                        ORDER BY CHANGE_TIMESTAMP DESC, SNAPSHOT_TIMESTAMP DESC
+                    )
+                    AS N
+            FROM SYNAPSE_DATA_WAREHOUSE_DanLu_STAGE.SYNAPSE_RAW.USERGROUPSNAPSHOTS --noqa: TMP
+            QUALIFY
+                N=1
+        )
+        SELECT * EXCLUDE N
+        FROM dedup_usergroup;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.22.0__usergroup_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.22.0__usergroup_latest.sql
@@ -15,7 +15,7 @@ CREATE OR REPLACE DYNAMIC TABLE USERGROUP_LATEST
                     AS N
             FROM {{database_name}}.SYNAPSE_RAW.USERGROUPSNAPSHOTS --noqa: TMP
             WHERE 
-                (SNAPSHOT_DATE >= CURRENT_TIMESTAMP - INTERVAL '14 days') 
+                SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL '14 days'
             QUALIFY
                 N=1
         )

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.22.0__usergroup_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.22.0__usergroup_latest.sql
@@ -1,7 +1,7 @@
 use schema {{database_name}}.synapse; --noqa: JJ01,PRS,TMP,CP01
 
 CREATE OR REPLACE DYNAMIC TABLE USERGROUP_LATEST
-    TARGET_LAG = DOWNSTREAM
+    TARGET_LAG = '1 day'
     WAREHOUSE = compute_xsmall
     AS
         WITH dedup_usergroup AS (
@@ -13,7 +13,9 @@ CREATE OR REPLACE DYNAMIC TABLE USERGROUP_LATEST
                         ORDER BY CHANGE_TIMESTAMP DESC, SNAPSHOT_TIMESTAMP DESC
                     )
                     AS N
-            FROM SYNAPSE_DATA_WAREHOUSE_DanLu_STAGE.SYNAPSE_RAW.USERGROUPSNAPSHOTS --noqa: TMP
+            FROM {{database_name}}.SYNAPSE_RAW.USERGROUPSNAPSHOTS --noqa: TMP
+            WHERE 
+                (SNAPSHOT_DATE >= CURRENT_TIMESTAMP - INTERVAL '14 days') 
             QUALIFY
                 N=1
         )


### PR DESCRIPTION
Problem:

USERGROUP_LATEST table is not populated in the database.

Solution(WIP):

Add dynamic table USERGROUP_LATEST via a version script to pull deduplicated data from USERGROUPSNAPSHOT table. 
 
Test:

Tested in my personal stage data warehouse:
1. created `USERGROUP_LATEST` table and check for the ID `3576543` and get one row. 
<img width="1337" alt="Screenshot 2024-11-08 at 11 30 15 AM" src="https://github.com/user-attachments/assets/1fe7db91-99bd-4b64-93c4-f8e46ea9e8af">
2. Modified the base table `USERGROUPSNAPSHOT` by inserting two rows with newer `CHANGETIMESTAMP`
<img width="1399" alt="Screenshot 2024-11-08 at 12 20 00 PM" src="https://github.com/user-attachments/assets/888f2891-2541-4673-912d-23f7208469b1">
3. Refreshed the `USERGROUP_LATEST` table and got the updated row  for the ID `3576543`.
<img width="1422" alt="Screenshot 2024-11-08 at 1 30 42 PM" src="https://github.com/user-attachments/assets/bc01c3de-21db-4689-bed5-835d35bf802a">



