### PR TITLE
[SNOW-29] Initialize dynamic table: `verificationsubmission_latest`

### DIFF
--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
@@ -4,25 +4,11 @@ CREATE DYNAMIC TABLE IF NOT EXISTS VERIFICATIONSUBMISSION_LATEST
     TARGET_LAG = '1 day'
     WAREHOUSE = compute_xsmall
     AS
-    WITH latest_rows AS (
-        SELECT
-            id AS latest_id,
-            MAX(snapshot_timestamp) AS latest_timestamp
-        FROM
-            verificationsubmissionsnapshots
-        GROUP BY
-            latest_id
-    ),
-    latest_unique_rows AS (
+    WITH latest_unique_rows AS (
         SELECT
             verificationsubmissionsnapshots.*,
         FROM
-            verificationsubmissionsnapshots
-        JOIN
-            latest_rows
-        ON
-            verificationsubmissionsnapshots.id = latest_rows.latest_id
-            AND verificationsubmissionsnapshots.snapshot_timestamp = latest_rows.latest_timestamp
+            {{database_name}}.synapse_raw.verificationsubmissionsnapshots --noqa: TMP
         QUALIFY ROW_NUMBER() OVER (
                 PARTITION BY id
                 ORDER BY snapshot_timestamp DESC

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
@@ -1,6 +1,6 @@
 use schema {{database_name}}.synapse; --noqa: JJ01,PRS,TMP,CP01
 
-CREATE OR REPLACE DYNAMIC TABLE VERIFICATIONSUBMISSION_LATEST
+CREATE DYNAMIC TABLE IF NOT EXISTS VERIFICATIONSUBMISSION_LATEST
     TARGET_LAG = '1 day'
     WAREHOUSE = compute_xsmall
     AS
@@ -17,7 +17,7 @@ CREATE OR REPLACE DYNAMIC TABLE VERIFICATIONSUBMISSION_LATEST
         SELECT
             verificationsubmissionsnapshots.*,
             ROW_NUMBER() OVER (
-                PARTITION BY snapshot_timestamp
+                PARTITION BY id
                 ORDER BY snapshot_timestamp DESC
             ) AS row_num
         FROM

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
@@ -6,12 +6,12 @@ CREATE OR REPLACE DYNAMIC TABLE VERIFICATIONSUBMISSION_LATEST
     AS
     WITH latest_rows AS (
         SELECT
-            verificationsubmissionsnapshots.id AS the_id,
+            id AS latest_id,
             MAX(snapshot_timestamp) AS latest_timestamp
         FROM
             verificationsubmissionsnapshots
         GROUP BY
-            verificationsubmissionsnapshots.id
+            latest_id
     ),
     latest_unique_rows AS (
         SELECT
@@ -25,11 +25,11 @@ CREATE OR REPLACE DYNAMIC TABLE VERIFICATIONSUBMISSION_LATEST
         JOIN
             latest_rows
         ON
-            verificationsubmissionsnapshots.id = latest_rows.the_id
+            verificationsubmissionsnapshots.id = latest_rows.latest_id
             AND verificationsubmissionsnapshots.snapshot_timestamp = latest_rows.latest_timestamp
     )
     SELECT
-        *
+        * EXCLUDE (row_num)
     FROM
         latest_unique_rows
     WHERE

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
@@ -11,6 +11,8 @@ CREATE DYNAMIC TABLE IF NOT EXISTS VERIFICATIONSUBMISSION_LATEST
             verificationsubmissionsnapshots.*,
         FROM
             {{database_name}}.synapse_raw.verificationsubmissionsnapshots --noqa: TMP
+        WHERE
+            SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL '14 DAYS'
         QUALIFY ROW_NUMBER() OVER (
                 PARTITION BY id
                 ORDER BY change_timestamp DESC, snapshot_timestamp DESC

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
@@ -33,4 +33,4 @@ CREATE DYNAMIC TABLE IF NOT EXISTS VERIFICATIONSUBMISSION_LATEST
     FROM
         latest_unique_rows
     ORDER BY
-        latest_unique_rows.id;
+        latest_unique_rows.id ASC;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
@@ -16,10 +16,6 @@ CREATE DYNAMIC TABLE IF NOT EXISTS VERIFICATIONSUBMISSION_LATEST
     latest_unique_rows AS (
         SELECT
             verificationsubmissionsnapshots.*,
-            ROW_NUMBER() OVER (
-                PARTITION BY id
-                ORDER BY snapshot_timestamp DESC
-            ) AS row_num
         FROM
             verificationsubmissionsnapshots
         JOIN
@@ -27,12 +23,14 @@ CREATE DYNAMIC TABLE IF NOT EXISTS VERIFICATIONSUBMISSION_LATEST
         ON
             verificationsubmissionsnapshots.id = latest_rows.latest_id
             AND verificationsubmissionsnapshots.snapshot_timestamp = latest_rows.latest_timestamp
+        QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY id
+                ORDER BY snapshot_timestamp DESC
+            ) = 1
     )
     SELECT
-        * EXCLUDE (row_num)
+        *
     FROM
         latest_unique_rows
-    WHERE
-        row_num = 1
     ORDER BY
         latest_unique_rows.id;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
@@ -1,0 +1,38 @@
+use schema {{database_name}}.synapse; --noqa: JJ01,PRS,TMP,CP01
+
+CREATE OR REPLACE DYNAMIC TABLE VERIFICATIONSUBMISSION_LATEST
+    TARGET_LAG = '1 day'
+    WAREHOUSE = compute_xsmall
+    AS
+    WITH latest_rows AS (
+        SELECT
+            verificationsubmissionsnapshots.id AS the_id,
+            MAX(snapshot_timestamp) AS latest_timestamp
+        FROM
+            verificationsubmissionsnapshots
+        GROUP BY
+            verificationsubmissionsnapshots.id
+    ),
+    latest_unique_rows AS (
+        SELECT
+            verificationsubmissionsnapshots.*,
+            ROW_NUMBER() OVER (
+                PARTITION BY snapshot_timestamp
+                ORDER BY snapshot_timestamp DESC
+            ) AS row_num
+        FROM
+            verificationsubmissionsnapshots
+        JOIN
+            latest_rows
+        ON
+            verificationsubmissionsnapshots.id = latest_rows.the_id
+            AND verificationsubmissionsnapshots.snapshot_timestamp = latest_rows.latest_timestamp
+    )
+    SELECT
+        *
+    FROM
+        latest_unique_rows
+    WHERE
+        row_num = 1
+    ORDER BY
+        latest_unique_rows.id;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.21.0__verificationsubmission_latest.sql
@@ -4,6 +4,8 @@ CREATE DYNAMIC TABLE IF NOT EXISTS VERIFICATIONSUBMISSION_LATEST
     TARGET_LAG = '1 day'
     WAREHOUSE = compute_xsmall
     AS
+    -- We deduplicate simply by selecting the latest record for each
+    -- verification submission ID...
     WITH latest_unique_rows AS (
         SELECT
             verificationsubmissionsnapshots.*,
@@ -11,7 +13,7 @@ CREATE DYNAMIC TABLE IF NOT EXISTS VERIFICATIONSUBMISSION_LATEST
             {{database_name}}.synapse_raw.verificationsubmissionsnapshots --noqa: TMP
         QUALIFY ROW_NUMBER() OVER (
                 PARTITION BY id
-                ORDER BY snapshot_timestamp DESC
+                ORDER BY change_timestamp DESC, snapshot_timestamp DESC
             ) = 1
     )
     SELECT


### PR DESCRIPTION
## problem

* The latest table for `verificationsubmissionsnapshots` does not exist in Snowflake.
* Following versioning best practices for Schemachange, we should initialize the dynamic table from a separate V script to mark its introduction into the system.

Associated with #81.

## solution

Add a V script to initialize `verificationsubmission_latest`

## testing

There are 19 unique submissions stored in the snapshots table, meaning there should be 19 total rows in the deduplicated latest table. The reason being that each submission can only be in 1 state - CREATED or UPDATED:

<img width="1318" alt="image" src="https://github.com/user-attachments/assets/642972a1-6618-496f-b52d-c77e801528b0">

We verify that the V script generates a table with 19 rows:

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/70cbd73a-c6de-4b67-97ad-92e5b766266d">

We verify that the 19 unique IDs in the snapshots table matches the 19 unique IDs in the latest table:

<img width="783" alt="image" src="https://github.com/user-attachments/assets/7fcf1fc9-492a-4385-94bb-8bfa835d33b7">

( This query would produce results if there were any missing IDs from either table )

We use a few IDs to manually verify that the latest state of each submission is reflected in the latest table:

- [x] 67

<img width="759" alt="image" src="https://github.com/user-attachments/assets/55caa62c-0842-4f64-8311-3f39023d26b4">
<img width="743" alt="image" src="https://github.com/user-attachments/assets/38ae25d4-b4df-42e6-b6d7-d593f7d44727">

- [x] 65

<img width="417" alt="image" src="https://github.com/user-attachments/assets/62871b79-b185-4b19-af66-97d2b31cf740">
<img width="316" alt="image" src="https://github.com/user-attachments/assets/88506fac-282b-4c8b-ac7a-c32a75df47a1">

- [x] 36

<img width="369" alt="image" src="https://github.com/user-attachments/assets/7a800f1b-56d9-4d11-9d9e-6157571bac3c">
<img width="309" alt="image" src="https://github.com/user-attachments/assets/633783bb-ad89-454d-ac5e-ed38e4fcff7e">

