### PR TITLE
[SNOW-82] Initialize dynamic table: `projectsetting_latest`

### DIFF
--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.24.0__projectsettings_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.24.0__projectsettings_latest.sql
@@ -1,0 +1,24 @@
+use schema {{database_name}}.synapse; --noqa: JJ01,PRS,TMP,CP01
+
+CREATE DYNAMIC TABLE IF NOT EXISTS PROJECTSETTING_LATEST
+    TARGET_LAG = '1 day'
+    WAREHOUSE = compute_xsmall
+    AS
+        WITH latest_unique_rows AS (
+            SELECT
+                *
+            FROM
+                {{database_name}}.synapse_raw.projectsettingsnapshots --noqa: TMP
+            WHERE
+                SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL '14 DAYS'
+            QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY id
+                    ORDER BY change_timestamp DESC, snapshot_timestamp DESC
+                ) = 1
+        )
+        SELECT
+            *
+        FROM
+            latest_unique_rows
+        ORDER BY
+            latest_unique_rows.id ASC;


### PR DESCRIPTION
### problem

About the data: The [Project Setting object](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/project/ProjectSetting.html) on Synapse is a project-based setting. The `projectsettingsnapshots` table contains records of all the states of a given project setting object. This includes when it was created, who it was created by, how it was last changed, and by whom, as well as other metadata like the setting type and what project this setting is for.

The latest table for `projectsettingsnapshots` does not exist in Snowflake. We should introduce a dynamic table that will reflect the latest state of a given project setting configuration on Synapse (i.e. whether it has been created, updated, or deleted, and all metadata which reflects this change)

### solution

A new Version script is created to introduce the dynamic table `projectsetting_latest` 

### testing

There are 2,282 rows in the final table; one for the latest state of each individual project setting configuration

<img width="333" alt="image" src="https://github.com/user-attachments/assets/b41b7357-b4ed-4036-a917-43e7105daef2">

From the snapshots table, we can confirm that there are 2,282 unique IDs

<img width="592" alt="image" src="https://github.com/user-attachments/assets/82ef6c1e-4d9e-4e89-bc17-5305c3dbd890">

This query ensures that all IDs are accounted for

<img width="460" alt="image" src="https://github.com/user-attachments/assets/254c5128-247e-447d-9530-c35bd8e5f804">

And this query ensures that the LATEST state is indeed the one that is reflected in the final table

<img width="811" alt="image" src="https://github.com/user-attachments/assets/63b9ae48-c672-4185-8b98-4756e49c3536">
