### PR TITLE
Fix SNOW-160 changes to dev

### DIFF
--- a/synapse_data_warehouse/synapse_raw/tasks/V2.25.1__update_node_tasks.sql
+++ b/synapse_data_warehouse/synapse_raw/tasks/V2.25.1__update_node_tasks.sql
@@ -3,6 +3,7 @@ USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP,CP02
 USE WAREHOUSE compute_xsmall;
 
 -- suspend nodesnapshot task and its dependents
+ALTER TASK refresh_synapse_warehouse_s3_stage_task SUSPEND;
 ALTER TASK nodesnapshot_task SUSPEND;
 ALTER TASK upsert_to_node_latest_task SUSPEND;
 ALTER TASK remove_delete_nodes_task SUSPEND;


### PR DESCRIPTION
I ran into the following error during the CI pipeline. I believe this is caused by not suspending the root task before trying to resume its dependents on this line: `SELECT SYSTEM$TASK_DEPENDENTS_ENABLE('refresh_synapse_warehouse_s3_stage_task');`

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.15/x64/bin/schemachange", line 8, in <module>
schemachange version: 3.6.1
Using config file: synapse_data_warehouse/schemachange-config.yml
Using root folder /home/runner/work/snowflake/snowflake/synapse_data_warehouse
Using variables:
  database_name: SYNAPSE_DATA_WAREHOUSE_DEV
  stage_storage_integration: synapse_dev_warehouse_s3
  stage_url: s3://dev.datawarehouse.sagebase.org/warehouse/
  stack: dev

Using Snowflake account ***
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schemachange/cli.py", line 896, in main
    deploy_command(config)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schemachange/cli.py", line 577, in deploy_command
    session.apply_change_script(script, content, change_history_table)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schemachange/cli.py", line 462, in apply_change_script
    self.execute_snowflake_query(script_content)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schemachange/cli.py", line 367, in execute_snowflake_query
    raise e
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schemachange/cli.py", line 360, in execute_snowflake_query
    res = self.con.execute_string(query)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/snowflake/connector/connection.py", line 888, in execute_string
    ret = list(stream_generator)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/snowflake/connector/connection.py", line 906, in execute_stream
    cur.execute(sql, _is_put_get=is_put_or_get, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/snowflake/connector/cursor.py", line 1097, in execute
    Error.errorhandler_wrapper(self.connection, self, error_class, errvalue)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/snowflake/connector/errors.py", line [28](https://github.com/Sage-Bionetworks/snowflake/actions/runs/12242803654/job/34150924180#step:5:29)4, in errorhandler_wrapper
    handed_over = Error.hand_to_other_handler(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/snowflake/connector/errors.py", line 339, in hand_to_other_handler
    cursor.errorhandler(connection, cursor, error_class, error_value)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/snowflake/connector/errors.py", line 215, in default_errorhandler
    raise error_class(
snowflake.connector.errors.ProgrammingError: 091421 (22000): Unable to update graph with root task SYNAPSE_DATA_WAREHOUSE_DEV.SYNAPSE_RAW.REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK since that root task is not suspended.
Using default role SYSADMIN
Using default warehouse compute_xsmall
Using default database SYNAPSE_DATA_WAREHOUSE_DEVschema None
Using change history table SYNAPSE_DATA_WAREHOUSE_DEV.SCHEMACHANGE.CHANGE_HISTORY (last altered 2024-11-22 08:24:16.548000-08:00)
Max applied change script version: 2.24.0
Applying change script V2.25.0__add_version_history_to_nodesnapshot.sql
Applying change script V2.25.1__update_node_tasks.sql
Error: Process completed with exit code 1.
```