### PR TITLE
[SNOW-175] `node_latest` dynamic table query update: Add stricter filter to remove deleted nodes

### DIFF
--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.26.5__remove_ghost_assets_node_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.26.5__remove_ghost_assets_node_latest.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE DYNAMIC TABLE NODE_LATEST
             FROM
                 {{database_name}}.synapse_raw.nodesnapshots --noqa: TMP
             WHERE
-                SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL '30 DAYS'
+                SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL '21 DAYS'
             QUALIFY ROW_NUMBER() OVER (
                     PARTITION BY id
                     ORDER BY change_timestamp DESC, snapshot_timestamp DESC

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.26.5__remove_ghost_assets_node_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.26.5__remove_ghost_assets_node_latest.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE DYNAMIC TABLE NODE_LATEST
             FROM
                 {{database_name}}.synapse_raw.nodesnapshots --noqa: TMP
             WHERE
-                SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL '21 DAYS'
+                SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL '30 DAYS'
             QUALIFY ROW_NUMBER() OVER (
                     PARTITION BY id
                     ORDER BY change_timestamp DESC, snapshot_timestamp DESC

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.26.5__remove_ghost_assets_node_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.26.5__remove_ghost_assets_node_latest.sql
@@ -1,0 +1,26 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+CREATE OR REPLACE DYNAMIC TABLE NODE_LATEST
+    TARGET_LAG = '1 day'
+    WAREHOUSE = compute_xsmall
+    AS
+        WITH latest_unique_rows AS (
+            SELECT
+                *
+            FROM
+                {{database_name}}.synapse_raw.nodesnapshots --noqa: TMP
+            WHERE
+                SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL '30 DAYS'
+            QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY id
+                    ORDER BY change_timestamp DESC, snapshot_timestamp DESC
+                ) = 1
+        )
+        SELECT
+            *
+        FROM
+            latest_unique_rows
+        WHERE
+            NOT (CHANGE_TYPE = 'DELETE' OR BENEFACTOR_ID = '1681355' OR PARENT_ID = '1681355') -- 1681355 is the synID of the trash can on Synapse
+        ORDER BY
+            latest_unique_rows.id ASC;


### PR DESCRIPTION
## problem

It was found that some nodes were incorrectly passing through the `CHANGE_TYPE != 'DELETE'` filter in the original query due to a misrepresentation of the latest `CHANGE_TYPE` for some deleted entities.

The reason for this misrepresentation is unclear, but is indirectly due to entities sitting in the trash can for 30 days leading to them being purged without a `DELETE` being recorded for this event. It also appears that this has something to do with the `PARENT_ID` of a node being changed, since the example we've seen this for had all their `CHANGE_TIMESTAMP`s locked on the date in which the parent entity was changed. As a result of this, all `CHANGE_TYPE`s were recorded with the same timestamp down to the second, resulting in `UPDATE` being the latest `CHANGE_TYPE` for these already-deleted nodes and leading to ghost nodes in the final latest table.

![image](https://github.com/user-attachments/assets/ef94ed23-26ee-44b2-834a-12de633dbc4a)

## solution

A [Jira ticket](https://sagebionetworks.jira.com/browse/PLFM-8747?atlOrigin=eyJpIjoiZTkzYjU4MmIyMWZhNDcxYmE5MTAxNjc0NTIxZjNkNTUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ) was created for the Platform team, and in this PR we introduce a workaround in the meantime, that involves stricter filtering of nodes that are deleted on Synapse. The trash can on Synapse behaves as a Synapse entity, therefore it has its own Synapse ID: `1681355`.

If we update the query to filter out nodes with a parent or benefactor of that same ID, we should be able to catch all deleted nodes.

## testing

The new solution is still not capturing all the deleted nodes, but we are getting better results than before.

The discrepancies that remain are a mix of entities that still exist but for some reason they haven't been snapshotted, and entities that were deleted but it's not represented on Snowflake. Entity `syn64129904` is an example of one that was deleted but its deletion was never recorded on Snowflake. It had no recorded change to its parent entity.

Results from original solution:
For 14 days - 25,837,058 rows
For 30 days - 25,863,689 rows

Results from new solution
For 14 days - 25647157
For 30 days - 25647216

In other words, the num. of discrepancies were brought down from 26,631 to 59 (as of Dec 13, 2024)