### PR TITLE
[SNOW-85] Document RAW tables

### DIFF
--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.0__document_aclsnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.0__document_aclsnapshots.sql
@@ -1,0 +1,14 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE aclsnapshots IS 'This table contain snapshots of access-control-list. Snapshots are taken when an acl is created, updated or deleted. Note: Snapshots are also taken periodically and independently of the changes. The snapshot_timestamp records when the snapshot was taken.';
+
+-- Add column comments
+COMMENT ON COLUMN aclsnapshots.change_timestamp IS 'The time when the change (created/updated/deleted) on an acl is pushed to the queue for snapshotting.';
+COMMENT ON COLUMN aclsnapshots.change_type IS 'The type of change that occurred on the acl, e.g., CREATE, UPDATE, DELETE.';
+COMMENT ON COLUMN aclsnapshots.snapshot_timestamp IS 'The time when the snapshot was taken (It is usually after the change happened).';
+COMMENT ON COLUMN aclsnapshots.owner_id IS 'The unique identifier of the Synapse object to which the acl is applied.';
+COMMENT ON COLUMN aclsnapshots.owner_type IS 'The type of the Synapse object that the acl is affecting, .e.g., ENTITY, FILE, SUBMISSION, MESSAGE, TEAM.';
+COMMENT ON COLUMN aclsnapshots.created_on IS 'The creation time of the acl.';
+COMMENT ON COLUMN aclsnapshots.resource_access IS 'The list of principals (users or teams) along with the permissions the principal is granted on the object to which the acl is applied.';
+COMMENT ON COLUMN aclsnapshots.snapshot_date IS 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.10__document_teammembersnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.10__document_teammembersnapshots.sql
@@ -1,0 +1,14 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE teammembersnapshots IS 'This table contain snapshots of team-members. Snapshots are captured when a team and/or its members are modified. Note: Snapshots are also taken periodically and independently of the changes. The snapshot_timestamp records when the snapshot was taken.';
+
+-- Add column comments
+COMMENT ON COLUMN teammembersnapshots.change_type IS 'The type of change that occurred to the member of team, e.g., CREATE, UPDATE (Snapshotting does not capture DELETE change).';
+COMMENT ON COLUMN teammembersnapshots.change_timestamp IS 'The time when any change to the team was made (e.g. update of the team or a change to its members).';
+COMMENT ON COLUMN teammembersnapshots.change_user_id IS 'The unique identifier of the user who made the change to the team member.';
+COMMENT ON COLUMN teammembersnapshots.snapshot_timestamp IS 'The time when the snapshot was taken (It is usually after the change happened).';
+COMMENT ON COLUMN teammembersnapshots.team_id IS 'The unique identifier of the team.';
+COMMENT ON COLUMN teammembersnapshots.member_id IS 'The unique identifier of the member of the team. The member is a Synapse user.';
+COMMENT ON COLUMN teammembersnapshots.is_admin IS 'If true, then the member is manager of the team.';
+COMMENT ON COLUMN teammembersnapshots.snapshot_date IS 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.11__document_teamsnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.11__document_teamsnapshots.sql
@@ -1,0 +1,18 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE teamsnapshots IS 'This table contain snapshots of teams. Snapshots are taken when teams or its members are created or updated. Note: Snapshots are also taken periodically and independently of the changes. The snapshot_timestamp records when the snapshot was taken.';
+
+-- Add column comments
+COMMENT ON COLUMN teamsnapshots.change_type IS 'The type of change that occurred to the team, e.g., CREATE, UPDATE (Snapshotting does not capture DELETE change).';
+COMMENT ON COLUMN teamsnapshots.change_timestamp IS 'The time when any change to the team was made (e.g. create, update or a change to its members).';
+COMMENT ON COLUMN teamsnapshots.change_user_id IS 'The unique identifier of the user who made the change to the team.';
+COMMENT ON COLUMN teamsnapshots.snapshot_timestamp IS 'The time when the snapshot was taken (It is usually after the change happened).';
+COMMENT ON COLUMN teamsnapshots.id IS 'The unique identifier of the team.';
+COMMENT ON COLUMN teamsnapshots.name IS 'The name of the team.';
+COMMENT ON COLUMN teamsnapshots.can_public_join IS 'If true, a user can join the team without approval of a team manager.';
+COMMENT ON COLUMN teamsnapshots.created_by IS 'The unique identifier of the user who created the team.';
+COMMENT ON COLUMN teamsnapshots.created_on IS 'The creation time of the team.';
+COMMENT ON COLUMN teamsnapshots.modified_by IS 'The unique identifier of the user who last modified the team.';
+COMMENT ON COLUMN teamsnapshots.modified_on IS 'The time when the team was last modified.';
+COMMENT ON COLUMN teamsnapshots.snapshot_date IS 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.12__document_usergroupsnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.12__document_usergroupsnapshots.sql
@@ -1,0 +1,14 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE usergroupsnapshots IS 'This table lists all principals (individual users and groups of users). (A group is the low-level object of a underlying team, much like a file handle is the low-level object of an underlying file entity.) In addition to explicit users and teams, principals in Synapse include the anonymous user, the implicit group of all authenticated users, and the implicit public group which includes all users, authenticated or not. Note: Snapshots are also taken periodically and independently of the changes. The snapshot_timestamp records when the snapshot was taken.';
+
+-- Add column comments
+COMMENT ON COLUMN usergroupsnapshots.change_type IS 'The type of change that occurred to the user-group, e.g., CREATE, UPDATE (Snapshotting does not capture DELETE change).';
+COMMENT ON COLUMN usergroupsnapshots.change_timestamp IS 'The time when the change (creation/update) to the user-group is pushed to the queue for snapshotting.';
+COMMENT ON COLUMN usergroupsnapshots.change_user_id IS 'The unique identifier of the user who made the change to the user-group.';
+COMMENT ON COLUMN usergroupsnapshots.snapshot_timestamp IS 'The time when the snapshot was taken (It is usually after the change happened).';
+COMMENT ON COLUMN usergroupsnapshots.id IS 'The unique identifier of user or group.';
+COMMENT ON COLUMN usergroupsnapshots.is_individual IS 'If true, then this user group is an individual user not a team.';
+COMMENT ON COLUMN usergroupsnapshots.created_on IS 'The creation time of the user or group.';
+COMMENT ON COLUMN usergroupsnapshots.snapshot_date IS 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.13__document_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.13__document_userprofilesnapshots.sql
@@ -1,0 +1,20 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE userprofilesnapshot IS 'This table contain snapshots of user-profiles. Snapshots are taken when user profiles are created or modified. Note: Snapshots are also taken periodically and independently of the changes. The snapshot_timestamp records when the snapshot was taken.';
+
+-- Add column comments
+COMMENT ON COLUMN userprofilesnapshot.change_type IS 'The type of change that occurred to the user profile, e.g., CREATE, UPDATE (Snapshotting does not capture DELETE change).';
+COMMENT ON COLUMN userprofilesnapshot.change_timestamp IS 'The time when any change to the user profile was made (e.g. create or update).';
+COMMENT ON COLUMN userprofilesnapshot.change_user_id IS 'The unique identifier of the user who made the change to the user profile.';
+COMMENT ON COLUMN userprofilesnapshot.snapshot_timestamp IS 'The time when the snapshot was taken (It is usually after the change happened).';
+COMMENT ON COLUMN userprofilesnapshot.id IS 'The unique identifier of the user.';
+COMMENT ON COLUMN userprofilesnapshot.user_name IS 'The Synapse username.';
+COMMENT ON COLUMN userprofilesnapshot.first_name IS 'The first name of the user.';
+COMMENT ON COLUMN userprofilesnapshot.last_name IS 'The last name of the user.';
+COMMENT ON COLUMN userprofilesnapshot.email IS 'The primary email of the user.';
+COMMENT ON COLUMN userprofilesnapshot.location IS 'The location of the user.';
+COMMENT ON COLUMN userprofilesnapshot.company IS 'The company where the user works.';
+COMMENT ON COLUMN userprofilesnapshot.position IS 'The position of the user in the company.';
+COMMENT ON COLUMN userprofilesnapshot.created_on IS 'The creation time of the user profile.';
+COMMENT ON COLUMN userprofilesnapshot.snapshot_date IS 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.14__document_verificationsubmissionsnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.14__document_verificationsubmissionsnapshots.sql
@@ -1,0 +1,14 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE verificationsubmissionsnapshots IS 'This table contain snapshots of submissions of user verification data by ACT. Snapshots are taken when a submission is created or updated. Note: Snapshots are also taken periodically and independently of the changes. The snapshot_timestamp records when the snapshot was taken.';
+
+-- Add column comments
+COMMENT ON COLUMN verificationsubmissionsnapshots.change_timestamp IS 'The time when the change (created/updated) on a submission is pushed to the queue for snapshotting.';
+COMMENT ON COLUMN verificationsubmissionsnapshots.change_type IS 'The type of change that occurred on the submission, e.g., CREATE, UPDATE.';
+COMMENT ON COLUMN verificationsubmissionsnapshots.snapshot_timestamp IS 'The time when the snapshot was taken (It is usually after the change happened).';
+COMMENT ON COLUMN verificationsubmissionsnapshots.id IS 'The unique identifier of the submission.';
+COMMENT ON COLUMN verificationsubmissionsnapshots.created_on IS 'The creation time of the submission.';
+COMMENT ON COLUMN verificationsubmissionsnapshots.created_by IS 'The unique identifier of the user who, created the submission';
+COMMENT ON COLUMN verificationsubmissionsnapshots.state_history IS 'The sequence of submission states (SUBMITTED, REJECTED, APPROVED) for the submission.';
+COMMENT ON COLUMN verificationsubmissionsnapshots.snapshot_date IS 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.1__document_certifiedquiz.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.1__document_certifiedquiz.sql
@@ -1,0 +1,13 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE certifiedquiz IS 'This table contain records of the certification quiz taken by a Synapse user.';
+
+-- Add column comments
+COMMENT ON COLUMN certifiedquiz.response_id IS 'The unique identifier of a response wherein a user submitted a set of answers while participating in the quiz.';
+COMMENT ON COLUMN certifiedquiz.user_id IS 'The unique identifier of the user who took the quiz.';
+COMMENT ON COLUMN certifiedquiz.passed IS 'If true, the user passed the quiz.';
+COMMENT ON COLUMN certifiedquiz.passed_on IS 'The date on which the user took the quiz, regardless of whether user passed or failed the test.';
+COMMENT ON COLUMN certifiedquiz.stack IS 'The stack (prod, dev) on which the quiz record was processed.';
+COMMENT ON COLUMN certifiedquiz.instance IS 'The version of the stack that processed the quiz record.';
+COMMENT ON COLUMN certifiedquiz.record_date IS 'The data is partitioned for fast and cost effective queries. The timestamp field is converted into a date and stored in the record_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.2__document_certifiedquizquestions.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.2__document_certifiedquizquestions.sql
@@ -1,11 +1,12 @@
 USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
 
 -- Add table comment
-COMMENT ON TABLE certifiedquizquestions IS 'This table contain records of the questions of the certification quiz. Each record in the table is question answered by the user in the quiz.';
+COMMENT ON TABLE certifiedquizquestion IS 'This table contain records of the questions of the certification quiz. Each record in the table is question answered by the user in the quiz.';
 
 -- Add column comments
-COMMENT ON COLUMN certifiedquizquestions.response_id IS 'The unique identifier of a response wherein a user submitted a set of answers while participating in the quiz.';
-COMMENT ON COLUMN certifiedquizquestions.question_index IS 'The position of the question within the quiz.';
-COMMENT ON COLUMN certifiedquizquestions.is_correct IS 'If true, the answer to the question was correct.';
-COMMENT ON COLUMN certifiedquizquestions.stack IS 'The stack (prod, dev) on which the quiz question record was processed.';
-COMMENT ON COLUMN certifiedquizquestions.instance IS 'The version of the stack that processed the quiz question record.';
+COMMENT ON COLUMN certifiedquizquestion.response_id IS 'The unique identifier of a response wherein a user submitted a set of answers while participating in the quiz.';
+COMMENT ON COLUMN certifiedquizquestion.question_index IS 'The position of the question within the quiz.';
+COMMENT ON COLUMN certifiedquizquestion.is_correct IS 'If true, the answer to the question was correct.';
+COMMENT ON COLUMN certifiedquizquestion.stack IS 'The stack (prod, dev) on which the quiz question record was processed.';
+COMMENT ON COLUMN certifiedquizquestion.instance IS 'The version of the stack that processed the quiz question record.';
+COMMENT ON COLUMN certifiedquizquestion.record_date IS 'The data is partitioned for fast and cost effective queries. The timestamp field is converted into a date and stored in the record_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.2__document_certifiedquizquestions.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.2__document_certifiedquizquestions.sql
@@ -1,0 +1,11 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE certifiedquizquestions IS 'This table contain records of the questions of the certification quiz. Each record in the table is question answered by the user in the quiz.';
+
+-- Add column comments
+COMMENT ON COLUMN certifiedquizquestions.response_id IS 'The unique identifier of a response wherein a user submitted a set of answers while participating in the quiz.';
+COMMENT ON COLUMN certifiedquizquestions.question_index IS 'The position of the question within the quiz.';
+COMMENT ON COLUMN certifiedquizquestions.is_correct IS 'If true, the answer to the question was correct.';
+COMMENT ON COLUMN certifiedquizquestions.stack IS 'The stack (prod, dev) on which the quiz question record was processed.';
+COMMENT ON COLUMN certifiedquizquestions.instance IS 'The version of the stack that processed the quiz question record.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.3__document_certifiedquizquestionsnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.3__document_certifiedquizquestionsnapshots.sql
@@ -1,0 +1,16 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE certifiedquizquestionsnapshots IS 'This table contain snapshots of the questions of the certification quiz. With each entry representing a question answered by the user during the quiz.';
+
+-- Add column comments
+COMMENT ON COLUMN certifiedquizquestionsnapshots.change_type IS 'The change type is always as CREATE since each instance of a user submitting a quiz results in a new submission of the quiz.';
+COMMENT ON COLUMN certifiedquizquestionsnapshots.change_timestamp IS 'The time when the user submitted the quiz.';
+COMMENT ON COLUMN certifiedquizquestionsnapshots.change_user_id IS 'The unique identifier of the user that submitted the quiz.';
+COMMENT ON COLUMN certifiedquizquestionsnapshots.snapshot_timestamp IS 'The time when the snapshot was taken (It is usually after the change happened).';
+COMMENT ON COLUMN certifiedquizquestionsnapshots.response_id IS 'The unique identifier of a response wherein a user submitted a set of answers while participating in the quiz.';
+COMMENT ON COLUMN certifiedquizquestionsnapshots.question_index IS 'The position of the question within the quiz.';
+COMMENT ON COLUMN certifiedquizquestionsnapshots.is_correct IS 'If true, the answer to the question was correct.';
+COMMENT ON COLUMN certifiedquizquestionsnapshots.stack IS 'The stack (prod, dev) on which the quiz question record was processed.';
+COMMENT ON COLUMN certifiedquizquestionsnapshots.instance IS 'The version of the stack that processed the quiz question record.';
+COMMENT ON COLUMN certifiedquizquestionsnapshots.snapshot_date IS 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.4__document_certifiedquizsnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.4__document_certifiedquizsnapshots.sql
@@ -1,0 +1,18 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE certifiedquizsnapshots IS 'This table contain snapshots of the certification quiz submitted by a Synapse user. Snapshots are taken when a user submit the quiz. Note: Snapshots are also taken periodically and independently of the changes. The snapshot_timestamp records when the snapshot was taken.';
+
+-- Add column comments
+COMMENT ON COLUMN certifiedquizsnapshots.change_type IS 'The change type is always as CREATE since each instance of a user submitting a quiz results in a new submission of the quiz.';
+COMMENT ON COLUMN certifiedquizsnapshots.change_timestamp IS 'The latest time when the change message was sent to the queue for snapshotting.';
+COMMENT ON COLUMN certifiedquizsnapshots.snapshot_timestamp IS 'The time when the snapshot was taken (It is usually after the change happened).';
+COMMENT ON COLUMN certifiedquizsnapshots.response_id IS 'The unique identifier of a response wherein a user submitted a set of answers while participating in the quiz.';
+COMMENT ON COLUMN certifiedquizsnapshots.user_id IS 'The unique identifier of the user who submitted the quiz.';
+COMMENT ON COLUMN certifiedquizsnapshots.passed IS 'If true, the user passed the quiz.';
+COMMENT ON COLUMN certifiedquizsnapshots.passed_on IS 'The date on which the user submit the quiz, regardless of whether user passed or failed the test.';
+COMMENT ON COLUMN certifiedquizsnapshots.stack IS 'The stack (prod, dev) on which the quiz record was processed.';
+COMMENT ON COLUMN certifiedquizsnapshots.instance IS 'The version of the stack that processed the quiz record.';
+COMMENT ON COLUMN certifiedquizsnapshots.revoked IS 'If true, the record was revoked by an ACT member.';
+COMMENT ON COLUMN certifiedquizsnapshots.revoked_on IS 'The date/time when the record was revoked, can be null if the record was never revoked.';
+COMMENT ON COLUMN certifiedquizsnapshots.certified IS 'If true the user is certified through this record, can be true iif passed is true and revoked is false.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.5__document_filedownload.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.5__document_filedownload.sql
@@ -1,0 +1,17 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE filedownload IS 'The table contain records of all the downloads of the Synapse, e.g., file, zip/package, attachments. The events are recorded only after the pre-signed url for requested download entity is generated.';
+
+-- Add column comments
+COMMENT ON COLUMN filedownload.timestamp IS 'The time when the file download event is pushed to the queue for recording, after generating the pre-signed url.';
+COMMENT ON COLUMN filedownload.user_id IS 'The id of the user who downloaded the file.';
+COMMENT ON COLUMN filedownload.project_id IS 'The unique identifier of the project where the downloaded entity resides. Applicable only for FileEntity and TableEntity.';
+COMMENT ON COLUMN filedownload.file_handle_id IS 'The unique identifier of the file handle.';
+COMMENT ON COLUMN filedownload.downloaded_file_handle_id IS 'The unique identifier of the zip file handle containing the downloaded file when the download is requested as zip/package, otherwise the id of the file handle itself.';
+COMMENT ON COLUMN filedownload.association_object_id IS 'The unique identifier of the Synapse object (without ''syn'' prefix) that wraps the file.';
+COMMENT ON COLUMN filedownload.association_object_type IS 'The type of the Synapse object that wraps the file, e.g., FileEntity, TableEntity, WikiAttachment, WikiMarkdown, UserProfileAttachment, MessageAttachment, TeamAttachment.';
+COMMENT ON COLUMN filedownload.stack IS 'The stack (prod, dev) on which the download request was processed.';
+COMMENT ON COLUMN filedownload.instance IS 'The version of the stack that processed the download request.';
+COMMENT ON COLUMN filedownload.session_id IS 'The UUID assigned to the API request that triggered this download.  By joining this table with the processedaccessrecord on session_id, more information about the call that triggered this download can be found.';
+COMMENT ON COLUMN filedownload.record_date IS 'The data is partitioned for fast and cost effective queries. The timestamp field is converted into a date and stored in the record_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.6__document_fileinventory.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.6__document_fileinventory.sql
@@ -1,0 +1,20 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE fileinventory IS 'This table contains the S3 inventory of the main synapse bucket, the inventory is a snapshot taken weekly. For more information see https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-inventory.html.';
+
+-- Add column comments
+COMMENT ON COLUMN fileinventory.bucket IS 'The object bucket';
+COMMENT ON COLUMN fileinventory.key IS 'The object key name (or key) that uniquely identifies the object in the bucket';
+COMMENT ON COLUMN fileinventory.encryption_status IS 'The server-side encryption status, depending on what kind of encryption key is used—an Amazon S3 managed (SSE-S3) key, an AWS Key Management Service (AWS KMS) key (SSE-KMS), or a customer-provided key (SSE-C). Set to SSE-S3, SSE-C, SSE-KMS, or NOT-SSE. A status of NOT-SSE means that the object is not encrypted with server-side encryption. For more information, see Protecting data with encryption.';
+COMMENT ON COLUMN fileinventory.is_latest IS 'Set to True if the object is the current version of the object';
+COMMENT ON COLUMN fileinventory.is_delete_marker IS 'Set to True if the object is a delete marker';
+COMMENT ON COLUMN fileinventory.size IS 'The object size in bytes, not including the size of incomplete multipart uploads, object metadata, and delete markers';
+COMMENT ON COLUMN fileinventory.last_modified_date IS 'The object creation date or the last modified date, whichever is the latest.';
+COMMENT ON COLUMN fileinventory.e_tag IS 'The entity tag (ETag) is a hash of the object. The ETag reflects changes only to the contents of an object, not to its metadata. The ETag can be an MD5 digest of the object data. Whether it is depends on how the object was created and how it is encrypted.';
+COMMENT ON COLUMN fileinventory.storage_class IS 'The storage class that is used for storing the object. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html';
+COMMENT ON COLUMN fileinventory.intelligent_tiering_access_tier IS 'Access tier (frequent or infrequent) of the object if it is stored in the S3 Intelligent-Tiering storage class. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html#sc-dynamic-data-access';		
+COMMENT ON COLUMN fileinventory.is_multipart_uploaded IS 'Set to True if the object was uploaded as a multipart upload';
+COMMENT ON COLUMN fileinventory.snapshot_date IS 'An inventory snapshot is taken on a weekly cadence, the data is partitioned by the snapshot date';				
+COMMENT ON COLUMN fileinventory.object_owner IS 'The owner of the object';
+

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.7__document_filesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.7__document_filesnapshots.sql
@@ -1,0 +1,26 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE filesnapshots IS 'This table contain snapshots of file handles. Snapshots are taken when file handles are created, updated or deleted. Note: Snapshots are also taken periodically and independently of the changes. The snapshot_timestamp records when the snapshot was taken.';
+
+-- Add column comments
+COMMENT ON COLUMN filesnapshots.change_type IS 'The type of change that occurred on the file handle, e.g., CREATE, UPDATE, DELETE.';
+COMMENT ON COLUMN filesnapshots.change_timestamp IS 'The time when the change (created/updated/deleted) on the file is pushed to the queue for snapshotting.';
+COMMENT ON COLUMN filesnapshots.change_user_id IS 'The unique identifier of the user who made the change to the file.';
+COMMENT ON COLUMN filesnapshots.snapshot_timestamp IS 'The time when the snapshot was taken (It is usually after the change happened).';
+COMMENT ON COLUMN filesnapshots.id IS 'The unique identifier of the file handle.';
+COMMENT ON COLUMN filesnapshots.created_by IS 'The unique identifier of the user who created the file handle.';
+COMMENT ON COLUMN filesnapshots.created_on IS 'The creation timestamp of the file handle.';
+COMMENT ON COLUMN filesnapshots.modified_on IS 'The most recent change time of the file handle.';
+COMMENT ON COLUMN filesnapshots.concrete_type IS 'The type of the file handle. Allowed file handles are: S3FileHandle, ProxyFileHandle, ExternalFileHandle, ExternalObjectStoreFileHandle, GoogleCloudFileHandle.';
+COMMENT ON COLUMN filesnapshots.content_md5 IS 'The md5 hash (using MD5 algorithm) of the file referenced by the file handle.';
+COMMENT ON COLUMN filesnapshots.content_type IS 'Metadata about the content of the file, e.g., application/json, application/zip, application/octet-stream.';
+COMMENT ON COLUMN filesnapshots.file_name IS 'The name of the file referenced by the file handle.';
+COMMENT ON COLUMN filesnapshots.storage_location_id IS 'The identifier of the environment, where the physical files are stored.';
+COMMENT ON COLUMN filesnapshots.content_size IS 'The size of the file referenced by the file handle.';
+COMMENT ON COLUMN filesnapshots.bucket IS 'The bucket where the file is physically stored. Applicable for s3 and GCP, otherwise empty.';
+COMMENT ON COLUMN filesnapshots.key IS 'The key name uniquely identifies the object (file) in the bucket.';
+COMMENT ON COLUMN filesnapshots.preview_id IS 'The identifier of the file handle that contains a preview of the file referenced by this file handle.';
+COMMENT ON COLUMN filesnapshots.is_preview IS 'If true, the file referenced by this file handle is a preview of another file';
+COMMENT ON COLUMN filesnapshots.status IS 'The availability status of the file referenced by the file handle. AVAILABLE:  accessible via Synapse; UNLINKED: not referenced by Synapse and therefore available for garbage collection; ARCHIVED: the file has been garbage collected.';
+COMMENT ON COLUMN filesnapshots.snapshot_date IS 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.8__document_nodesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.8__document_nodesnapshots.sql
@@ -1,0 +1,41 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE nodesnapshots IS 'This table contain snapshots of nodes (Nodes are project, file, folders...). Snapshots are taken when nodes are created, updated or deleted. Note: Snapshots are also taken periodically and independently of the changes. The snapshot_timestamp is the time when the snapshot was taken.';
+
+-- Add column comments
+COMMENT ON COLUMN nodesnapshots.change_type IS 'The type of change that occurred on the node, e.g., CREATE, UPDATE, DELETE.';
+COMMENT ON COLUMN nodesnapshots.change_timestamp IS 'The time when the change (created/updated/deleted) on the node is pushed to the queue for snapshotting.';
+COMMENT ON COLUMN nodesnapshots.change_user_id IS 'The unique identifier of the user who made the change to the node.';
+COMMENT ON COLUMN nodesnapshots.snapshot_timestamp IS 'The time when the snapshot was taken. (It is usually after the change happened).';
+COMMENT ON COLUMN nodesnapshots.id IS 'The unique identifier of the node.';
+COMMENT ON COLUMN nodesnapshots.benefactor_id IS 'The identifier of the (ancestor) node which provides the permissions that apply to this node. Can be the id of the node itself.';
+COMMENT ON COLUMN nodesnapshots.project_id IS 'The project where the node resides. It will be empty for the change type DELETE.';
+COMMENT ON COLUMN nodesnapshots.parent_id IS 'The unique identifier of the parent in the node hierarchy.';
+COMMENT ON COLUMN nodesnapshots.node_type IS 'The type of the node. Allowed node types are : project, folder, file, table, link, entityview, dockerrepo, submissionview, dataset, datasetcollection, materializedview, virtualtable.';
+COMMENT ON COLUMN nodesnapshots.created_on IS 'The creation time of the node.';
+COMMENT ON COLUMN nodesnapshots.created_by IS 'The unique identifier of the user who created the node.';
+COMMENT ON COLUMN nodesnapshots.modified_on IS 'The most recent change time of the node.';
+COMMENT ON COLUMN nodesnapshots.modified_by IS 'The unique identifier of the user who last modified the node.';
+COMMENT ON COLUMN nodesnapshots.version_number IS 'The version of the node on which the change occurred, if applicable.';
+COMMENT ON COLUMN nodesnapshots.file_handle_id IS 'The unique identifier of the file handle if the node is a file, null otherwise.';
+COMMENT ON COLUMN nodesnapshots.name IS 'The name of the node.';
+COMMENT ON COLUMN nodesnapshots.version_comment IS 'A short description assigned to this node version.';
+COMMENT ON COLUMN nodesnapshots.version_label IS 'A short label assigned to this node version.';
+COMMENT ON COLUMN nodesnapshots.alias IS 'An alias assigned to a project entity if present.';
+COMMENT ON COLUMN nodesnapshots.activity_id IS 'The reference to the id of an activity assigned to the node.';
+COMMENT ON COLUMN nodesnapshots.column_model_ids IS 'For entities that define a table schema (e.g. table, views etc), the list of column ids assigned to the schema.';
+COMMENT ON COLUMN nodesnapshots.scope_ids IS 'For entities that define a scope (e.g. entity views, subsmission views etc), the list of entity ids included in the scope.';
+COMMENT ON COLUMN nodesnapshots.items IS 'For entities that define a fixed list of entity references (e.g. dataset, dataset collections), the list of entity references included in the scope.';
+COMMENT ON COLUMN nodesnapshots.reference IS 'For Link entities, the reference to the linked target.';
+COMMENT ON COLUMN nodesnapshots.is_search_enabled IS 'For Table like entities (e.g. EntityView, MaterializedView etc), defines if full text search is enabled on those entities.';
+COMMENT ON COLUMN nodesnapshots.defining_sql IS 'For tables that are driven by a synapse SQL query (e.g. MaterializedView, VirtualTable), defines the underlying SQL query.';
+COMMENT ON COLUMN nodesnapshots.is_public IS 'If true, READ permission is granted to all the Synapse users, including the anonymous user, at the time of the snapshot.';
+COMMENT ON COLUMN nodesnapshots.is_controlled IS 'If true, an access requirement managed by the ACT is set on the node.';
+COMMENT ON COLUMN nodesnapshots.is_restricted IS 'If true, a terms-of-use access requirement is set on the node.';
+COMMENT ON COLUMN nodesnapshots.effective_ars IS 'The list of access requirement ids that apply to the entity at the time the snapshot was taken.';
+COMMENT ON COLUMN nodesnapshots.annotations IS 'The json representation of the entity annotations assigned by the user.';
+COMMENT ON COLUMN nodesnapshots.derived_annotations IS 'The json representation of the entity annotations that were derived by the schema of the entity.';
+COMMENT ON COLUMN nodesnapshots.internal_annotations IS 'The json representation of the entity internal annotations that are used to store additional data about different types of entity (e.g. dataset checksum, size, count).';
+COMMENT ON COLUMN nodesnapshots.version_history IS 'The list of entity versions, at the time of the snapshot.';
+COMMENT ON COLUMN nodesnapshots.snapshot_date IS 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.27.9__document_processedaccess.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.27.9__document_processedaccess.sql
@@ -1,0 +1,33 @@
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP
+
+-- Add table comment
+COMMENT ON TABLE processedaccess IS 'The table contains access records. Each record reflects a single API request received by the Synapse server. The recorded data is useful for audits and to analyse API performance such as delays, errors or success rates.';
+
+-- Add column comments
+COMMENT ON COLUMN processedaccess.session_id IS 'A unique identifier that the Synapse server assigns for the duration of a session. Sessions are linked to a user, an API key or a token.';
+COMMENT ON COLUMN processedaccess.timestamp IS 'The timestamp when the user sends a request to the Synapse server.';
+COMMENT ON COLUMN processedaccess.user_id IS 'The unique identifier of the Synapse user.';
+COMMENT ON COLUMN processedaccess.method IS 'The http method of the request.';
+COMMENT ON COLUMN processedaccess.request_url IS 'The URL of the request.';
+COMMENT ON COLUMN processedaccess.user_agent IS 'The User-Agent header from the http request. See: https://en.wikipedia.org/wiki/User-Agent_header';
+COMMENT ON COLUMN processedaccess.host IS 'The IP address of the host that made the request.';
+COMMENT ON COLUMN processedaccess.origin IS 'The host name of the portal making the request, e.g., https://staging.synapse.org, https://adknowledgeportal.synapse.org, https://dhealth.synapse.org.';
+COMMENT ON COLUMN processedaccess.x_forwarded_for IS 'The HTTP header x_forwarded_for contains the IP address of the user connecting through a proxy. See: https://en.wikipedia.org/wiki/X-Forwarded-For';
+COMMENT ON COLUMN processedaccess.via IS 'The HTTP header Via, informs the server of proxies through which the request was sent.';
+COMMENT ON COLUMN processedaccess.thread_id IS 'The unique identifier of the thread in which the request was processed.';
+COMMENT ON COLUMN processedaccess.elapse_ms IS 'The total time of processing the user request in milliseconds.';
+COMMENT ON COLUMN processedaccess.success IS 'Indicates if the user request succeeded (true) or failed (false).';
+COMMENT ON COLUMN processedaccess.stack IS 'The stack (prod, dev) on which the request was processed.';
+COMMENT ON COLUMN processedaccess.instance IS 'The version of the stack that processed the request.';
+COMMENT ON COLUMN processedaccess.vm_id IS 'The unique identifier of the Synapse ec2 server in the cluster that processed the request.';
+COMMENT ON COLUMN processedaccess.return_object_id IS 'The Synapse object identifier which is returned to the user in response body of a GET, PUT or POST API, if available.';
+COMMENT ON COLUMN processedaccess.query_string IS 'The set of characters tacked onto the end of a URL after the question mark (?).';
+COMMENT ON COLUMN processedaccess.response_status IS 'The response code for the request, e.g., 200, 401, 500. See: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes';
+COMMENT ON COLUMN processedaccess.oauth_client_id IS 'The unique identifier of the oauth client used in the request. It will be empty when the request is not made by an OAuth client.';
+COMMENT ON COLUMN processedaccess.basic_auth_username IS 'The name of the user who made the request using BASIC authentication method. It will be empty otherwise.';
+COMMENT ON COLUMN processedaccess.auth_method IS 'The authentication method used by the client. Currently BEARERTOKEN, SESSIONTOKEN, BASIC, APIKEY methods are supported.';
+COMMENT ON COLUMN processedaccess.normalized_method_signature IS 'This is the http method followed by a simplified version of the request url (with all IDs extracted).';
+COMMENT ON COLUMN processedaccess.client IS 'The is an alias of the user agent, e.g., WEB, JAVA, PYTHON.';
+COMMENT ON COLUMN processedaccess.client_version IS 'The version of the client used to make the request.';
+COMMENT ON COLUMN processedaccess.entity_id IS 'The Synapse object identifier sent by the user in the request url, if any.';
+COMMENT ON COLUMN processedaccess.record_date IS 'The data is partitioned for fast and cost effective queries. The timestamp field is converted into a date and stored in the record_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.';


### PR DESCRIPTION
## problem

Most of the bronze layer tables and their columns were missing documentation.

## solution

Add table and column comments for all the bronze layer tables that don't have. I used the [Synapse-Stack-Builder](https://github.com/Sage-Bionetworks/Synapse-Stack-Builder/blob/f3b16e9c8cf0d919d136fd4e13d3490ac60220bf/src/main/resources/templates/datawarehouse/datawarehouse-config.json#L336) repo and the [Jira documentation](https://sagebionetworks.jira.com/wiki/spaces/DW/pages/3034775570/Raw+tables+in+Athena+Snowflake#File-Inventory) for column and table descriptions.

## testing

I ran all the scripts against the raw tables in [this clone](https://app.snowflake.com/mqzfhld/vp00034/#) and was able to confirm all table + column comments were applied.