### PR TITLE
[SNOW-60,162,165] Add new columns to `userprofilesnapshots`

### DIFF
--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.0__add_is_two_factor_auth_enabled_to_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.0__add_is_two_factor_auth_enabled_to_userprofilesnapshots.sql
@@ -2,6 +2,6 @@
 USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP,CP02
 
 -- Add new column
-ALTER TABLE userprofilesnapshot
-  ADD COLUMN is_two_factor_auth_enabled BOOLEAN
-  COMMENT 'Indicates if the user had two factor authentication enabled when the snapshot was captured.';
+ALTER TABLE userprofilesnapshot ADD COLUMN is_two_factor_auth_enabled BOOLEAN COMMENT 'Indicates if the user had two factor authentication enabled when the snapshot was captured.';
+ALTER TABLE userprofilesnapshot ADD COLUMN industry VARCHAR(255) COMMENT 'The industry/discipline that this person is associated with.';
+ALTER TABLE userprofilesnapshot ADD COLUMN tos_agreements VARIANT COMMENT 'Contains the list of all the term of service that the user agreed to, with their agreed on date and version.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.0__add_is_two_factor_auth_enabled_to_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.0__add_is_two_factor_auth_enabled_to_userprofilesnapshots.sql
@@ -1,0 +1,7 @@
+-- Configure environment
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP,CP02
+
+-- Add `version_history` column
+ALTER TABLE userprofilesnapshot
+  ADD COLUMN is_two_factor_auth_enabled BOOLEAN
+  COMMENT 'Indicates if the user had two factor authentication enabled when the snapshot was captured.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.0__add_is_two_factor_auth_enabled_to_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.0__add_is_two_factor_auth_enabled_to_userprofilesnapshots.sql
@@ -3,5 +3,5 @@ USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP,CP02
 
 -- Add new column
 ALTER TABLE userprofilesnapshot ADD COLUMN is_two_factor_auth_enabled BOOLEAN COMMENT 'Indicates if the user had two factor authentication enabled when the snapshot was captured.';
-ALTER TABLE userprofilesnapshot ADD COLUMN industry VARCHAR(255) COMMENT 'The industry/discipline that this person is associated with.';
+ALTER TABLE userprofilesnapshot ADD COLUMN industry STRING COMMENT 'The industry/discipline that this person is associated with.';
 ALTER TABLE userprofilesnapshot ADD COLUMN tos_agreements VARIANT COMMENT 'Contains the list of all the term of service that the user agreed to, with their agreed on date and version.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.0__add_is_two_factor_auth_enabled_to_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.0__add_is_two_factor_auth_enabled_to_userprofilesnapshots.sql
@@ -1,7 +1,7 @@
 -- Configure environment
 USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP,CP02
 
--- Add `version_history` column
+-- Add new column
 ALTER TABLE userprofilesnapshot
   ADD COLUMN is_two_factor_auth_enabled BOOLEAN
   COMMENT 'Indicates if the user had two factor authentication enabled when the snapshot was captured.';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
@@ -25,9 +25,6 @@ ALTER TASK userprofilesnapshot_task MODIFY AS
             $1:location as location,
             $1:company as company,
             $1:position as position,
-            $1:is_two_factor_auth_enabled as is_two_factor_auth_enabled,
-            $1:industry as industry,
-            $1:tos_agreements as tos_agreements,
             NULLIF(
                 REGEXP_REPLACE(
                     metadata$filename,
@@ -35,7 +32,10 @@ ALTER TASK userprofilesnapshot_task MODIFY AS
                 ),
                 '__HIVE_DEFAULT_PARTITION__'
             ) as snapshot_date,
-            $1:created_on as created_on
+            $1:created_on as created_on,
+            $1:is_two_factor_auth_enabled as is_two_factor_auth_enabled,
+            $1:industry as industry,
+            $1:tos_agreements as tos_agreements
         from
             @synapse_prod_warehouse_s3_stage/userprofilesnapshots --noqa: TMP
     )

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
@@ -5,7 +5,7 @@ USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP,CP02
 ALTER TASK refresh_synapse_warehouse_s3_stage_task SUSPEND;
 
 -- Suspend the child task in question
-ALTER TASK userprofilesnapshot_task SUSPEND
+ALTER TASK userprofilesnapshot_task SUSPEND;
 
 -- Add the new column to the child task
 ALTER TASK userprofilesnapshot_task MODIFY AS

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
@@ -1,0 +1,43 @@
+-- Configure environment
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP,CP02
+
+-- Suspend the root task
+ALTER TASK refresh_synapse_warehouse_s3_stage_task SUSPEND;
+
+-- Suspend the child task in question
+ALTER TASK userprofilesnapshot_task SUSPEND
+
+-- Add the new column to the child task
+ALTER TASK userprofilesnapshot_task MODIFY AS
+	COPY INTO
+        userprofilesnapshot
+    FROM (
+        SELECT
+            $1:change_type as change_type,
+            $1:change_timestamp as change_timestamp,
+            $1:change_user_id as change_user_id,
+            $1:snapshot_timestamp as snapshot_timestamp,
+            $1:id as id,
+            $1:user_name as user_name,
+            $1:first_name as first_name,
+            $1:last_name as last_name,
+            $1:email as email,
+            $1:location as location,
+            $1:company as company,
+            $1:position as position,
+            $1:is_two_factor_auth_enabled as is_two_factor_auth_enabled,
+            NULLIF(
+                REGEXP_REPLACE(
+                    metadata$filename,
+                    '.*userprofilesnapshots\/snapshot_date\=(.*)\/.*', '\\1'
+                ),
+                '__HIVE_DEFAULT_PARTITION__'
+            ) as snapshot_date,
+            $1:created_on as created_on
+        from
+            @synapse_prod_warehouse_s3_stage/userprofilesnapshots --noqa: TMP
+    )
+    pattern = '.*userprofilesnapshots/snapshot_date=.*/.*';
+
+-- Resume the ROOT task and its child task
+SELECT SYSTEM$TASK_DEPENDENTS_ENABLE( 'refresh_synapse_warehouse_s3_stage_task' );

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
@@ -26,6 +26,8 @@ ALTER TASK userprofilesnapshot_task MODIFY AS
             $1:company as company,
             $1:position as position,
             $1:is_two_factor_auth_enabled as is_two_factor_auth_enabled,
+            $1:industry as industry,
+            $1:tos_agreements as tos_agreements,
             NULLIF(
                 REGEXP_REPLACE(
                     metadata$filename,

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
@@ -22,6 +22,8 @@ FROM (
         $1:company as company,
         $1:position as position,
         $1:is_two_factor_auth_enabled as is_two_factor_auth_enabled,
+        $1:industry as industry,
+        $1:tos_agreements as tos_agreements,
         NULLIF(
             REGEXP_REPLACE(
                 metadata$filename,

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
@@ -1,0 +1,36 @@
+-- Configure environment
+USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP,CP02
+
+-- Drop all records from this table but keep structure and permissions intact
+TRUNCATE TABLE userprofilesnapshot;
+
+-- 
+COPY INTO
+        userprofilesnapshot
+FROM (
+    SELECT
+        $1:change_type as change_type,
+        $1:change_timestamp as change_timestamp,
+        $1:change_user_id as change_user_id,
+        $1:snapshot_timestamp as snapshot_timestamp,
+        $1:id as id,
+        $1:user_name as user_name,
+        $1:first_name as first_name,
+        $1:last_name as last_name,
+        $1:email as email,
+        $1:location as location,
+        $1:company as company,
+        $1:position as position,
+        $1:is_two_factor_auth_enabled as is_two_factor_auth_enabled,
+        NULLIF(
+            REGEXP_REPLACE(
+                metadata$filename,
+                '.*userprofilesnapshots\/snapshot_date\=(.*)\/.*', '\\1'
+            ),
+            '__HIVE_DEFAULT_PARTITION__'
+        ) as snapshot_date,
+        $1:created_on as created_on
+    from
+        @synapse_prod_warehouse_s3_stage/userprofilesnapshots --noqa: TMP
+)
+pattern = '.*userprofilesnapshots/snapshot_date=.*/.*';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
@@ -21,9 +21,6 @@ FROM (
         $1:location as location,
         $1:company as company,
         $1:position as position,
-        $1:is_two_factor_auth_enabled as is_two_factor_auth_enabled,
-        $1:industry as industry,
-        $1:tos_agreements as tos_agreements,
         NULLIF(
             REGEXP_REPLACE(
                 metadata$filename,
@@ -31,7 +28,10 @@ FROM (
             ),
             '__HIVE_DEFAULT_PARTITION__'
         ) as snapshot_date,
-        $1:created_on as created_on
+        $1:created_on as created_on,
+        $1:is_two_factor_auth_enabled as is_two_factor_auth_enabled,
+        $1:industry as industry,
+        $1:tos_agreements as tos_agreements
     from
         @synapse_prod_warehouse_s3_stage/userprofilesnapshots --noqa: TMP
 )


### PR DESCRIPTION
## problem

The parquet files now contain a new pieces of metadata `is_two_factor_auth_enabled` `industry` and `tos_agreements` but this metadata is not reflected in the current `userprofilesnapshots` table.

## solution

Following this SOP:
- [x] Write a V script to add the new columns to the snapshots table
- [x] Write a V script to alter the existing task that copies new data into the snapshots table
- [x] Write a V script to manually refresh the entire snapshots table with the new column values

## testing

I tested the queries of all the scripts in `SYNAPSE_DATA_WAREHOUSE_JMEDINA.synapse_raw.userprofilesnapshot` so the results are available there.

I did a cross-check using the `id` column for the `userprofilesnapshot` in `synapse_data_warehouse_dev` and `synapse_data_warehouse_jmedina` and can confirm that all the IDs are accounted for:

<img width="328" alt="image" src="https://github.com/user-attachments/assets/488f1aa1-4763-4a27-83cc-4445d01b11e3" />

The number of rows are also the same:

<img width="341" alt="image" src="https://github.com/user-attachments/assets/152865a9-e9b6-48ce-8706-2fde471e22cd" />

Let me know if you'd like me to share the worksheet where I ran these tests