### PR TITLE
[SNOW-60] Hotfix: Programmatically feed stage name

### DIFF
--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
@@ -37,7 +37,7 @@ ALTER TASK userprofilesnapshot_task MODIFY AS
             $1:industry as industry,
             $1:tos_agreements as tos_agreements
         from
-            @{{stage_storage_integration}}/userprofilesnapshots --noqa: TMP
+            @{{stage_storage_integration}}_stage/userprofilesnapshots --noqa: TMP
     )
     pattern = '.*userprofilesnapshots/snapshot_date=.*/.*';
 

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.1__update_userprofilesnapshots_task.sql
@@ -37,7 +37,7 @@ ALTER TASK userprofilesnapshot_task MODIFY AS
             $1:industry as industry,
             $1:tos_agreements as tos_agreements
         from
-            @synapse_prod_warehouse_s3_stage/userprofilesnapshots --noqa: TMP
+            @{{stage_storage_integration}}/userprofilesnapshots --noqa: TMP
     )
     pattern = '.*userprofilesnapshots/snapshot_date=.*/.*';
 

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
@@ -33,6 +33,6 @@ FROM (
         $1:industry as industry,
         $1:tos_agreements as tos_agreements
     from
-        @synapse_prod_warehouse_s3_stage/userprofilesnapshots --noqa: TMP
+        @{{stage_storage_integration}}/userprofilesnapshots --noqa: TMP
 )
 pattern = '.*userprofilesnapshots/snapshot_date=.*/.*';

--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
@@ -33,6 +33,6 @@ FROM (
         $1:industry as industry,
         $1:tos_agreements as tos_agreements
     from
-        @{{stage_storage_integration}}/userprofilesnapshots --noqa: TMP
+        @{{stage_storage_integration}}_stage/userprofilesnapshots --noqa: TMP
 )
 pattern = '.*userprofilesnapshots/snapshot_date=.*/.*';


### PR DESCRIPTION
Instead of programmatically feeding the stage name, I had it hardcoded to `prod`, which broke when deploying to `dev`.

This PR patches that up in both the task and refresh scripts.