### PR TITLE
[SNOW-60] Update the warehouse for the large refresh

### DIFF
--- a/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
+++ b/synapse_data_warehouse/synapse_raw/tables/V2.28.2__refresh_userprofilesnapshots.sql
@@ -1,5 +1,6 @@
 -- Configure environment
 USE SCHEMA {{database_name}}.synapse_raw; --noqa: JJ01,PRS,TMP,CP02
+USE WAREHOUSE compute_medium;
 
 -- Drop all records from this table but keep structure and permissions intact
 TRUNCATE TABLE userprofilesnapshot;


### PR DESCRIPTION
The refresh takes >10 mins to run for 400K rows in `dev` so it's worth bumping it up from xsmall->medium for the large refresh, since `prod` has >14m rows

The task will use xsmall since that's an incremental update 