### PR TITLE
[SNOW-171] Revisit de-duplication for `certifiedquizquestion_latest` dynamic table

### DIFF
--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.31.0__fix_certifiedquizquestion_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.31.0__fix_certifiedquizquestion_latest.sql
@@ -1,0 +1,31 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+WITH latest_change_type AS (
+    SELECT
+        response_id,
+        MAX(change_type) AS change_type
+    FROM
+        {{database_name}}.synapse_raw.certifiedquizquestionsnapshots
+    GROUP BY
+        response_id
+),
+relevant_snapshots AS (
+    SELECT
+        s.*
+    FROM
+        {{database_name}}.synapse_raw.certifiedquizquestionsnapshots s
+    JOIN
+        latest_change_type l
+    ON
+        s.response_id = l.response_id
+    WHERE
+        s.change_type = l.change_type
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY s.response_id, s.question_index
+        ORDER BY
+            CASE WHEN s.change_type = 'CREATE' THEN s.change_timestamp END ASC NULLS LAST,
+            CASE WHEN s.change_type = 'UPDATE' THEN s.snapshot_timestamp END DESC NULLS LAST
+    ) = 1
+)
+SELECT *
+FROM relevant_snapshots;


### PR DESCRIPTION
## problem

The way snapshots are collected for the `certifiedquizquestionsnapshots` table can sometimes lead to inaccuracies in the `CHANGE_TIMESTAMP` column if a user ends up re-taking the quiz multiple times (and thus generating multiple `response_id`s for a given user.

[See this comment](https://sagebionetworks.jira.com/browse/SNOW-171?focusedCommentId=232311) for a summary and visual of what the problem is.

## solution

This snapshots table acts as a record table for the most part. Users cannot delete their submissions, nor can they go back and change their answers. As such, most of these snapshots are `CREATE` types. They CAN, however, revoke previous submission results if they re-take the quiz and pass. This is the only time we would find an `UPDATE` snapshot type.

Because of this, we can be pretty forgiving in the way we de-duplicate responses. They do NOT need to be the latest snapshots, so long as there was no `UPDATE` change snapshotted.

We _do_ want to ensure that the `change_timestamp` (the time of quiz submission) is captured correctly. As such, the solution is:

1. Order responses that do not have an `UPDATE` in their history by `change_timestamp ASC`
2. Order responses that do have an `UPDATE` in their history by `snapshot_timestamp DESC`

And grab the first row of each (i.e. get the earliest snapshot for 1 and the latest snapshot for 2)

## testing