### PR TITLE
[SNOW-222] Reintroduce `node_latest` dynamic table

### DIFF
--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.35.3__replace_node_latest.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.35.3__replace_node_latest.sql
@@ -1,0 +1,61 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+CREATE OR REPLACE DYNAMIC TABLE NODE_LATEST
+    TARGET_LAG = '1 day'
+    WAREHOUSE = compute_xsmall
+    AS
+        WITH latest_unique_rows AS (
+            SELECT
+                CHANGE_TYPE,
+                CHANGE_TIMESTAMP,
+                CHANGE_USER_ID,
+                SNAPSHOT_TIMESTAMP,
+                ID,
+                BENEFACTOR_ID,
+                PROJECT_ID,
+                PARENT_ID,
+                NODE_TYPE,
+                CREATED_ON,
+                CREATED_BY,
+                MODIFIED_ON,
+                MODIFIED_BY,
+                VERSION_NUMBER,
+                FILE_HANDLE_ID,
+                NAME,
+                IS_PUBLIC,
+                IS_CONTROLLED,
+                IS_RESTRICTED,
+                SNAPSHOT_DATE,
+                EFFECTIVE_ARS,
+                ANNOTATIONS,
+                DERIVED_ANNOTATIONS,
+                VERSION_COMMENT,
+                VERSION_LABEL,
+                ALIAS,
+                ACTIVITY_ID,
+                COLUMN_MODEL_IDS,
+                SCOPE_IDS,
+                ITEMS,
+                REFERENCE,
+                IS_SEARCH_ENABLED,
+                DEFINING_SQL,
+                INTERNAL_ANNOTATIONS,
+                VERSION_HISTORY,
+                PROJECT_STORAGE_USAGE
+            FROM
+                {{database_name}}.synapse_raw.nodesnapshots --noqa: TMP
+            WHERE
+                SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL '30 DAYS'
+            QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY id
+                    ORDER BY change_timestamp DESC, snapshot_timestamp DESC
+                ) = 1
+        )
+        SELECT
+            *
+        FROM
+            latest_unique_rows
+        WHERE
+            NOT (CHANGE_TYPE = 'DELETE' OR BENEFACTOR_ID = '1681355' OR PARENT_ID = '1681355') -- 1681355 is the synID of the trash can on Synapse
+        ORDER BY
+            latest_unique_rows.id ASC;


### PR DESCRIPTION
## problem

We recently made a structural change to `nodesnapshots` by adding a new column, which resulted in the `node_latest` dynamic table breaking with the message in the screenshot below:

![image](https://github.com/user-attachments/assets/5264aef1-5c41-4ac0-80e6-0d1f40166617)


## solution

From the Snowflake devs:

> _When you add or remove a column to a table, if that column is unused, there will be no issues. If the column is used (in which case, a SELECT * is using the new column) this will result in the error you see._ 

The solution is to:

- [x] Reintroduce the `node_latest` dynamic table, explicitly SELECTing the columns that currently exist, to show how the table structure is changing.
- [x] Add a final step in [the SOP](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/3813015566/Adding+a+column+to+an+existing+snapshots+table) to re-introduce any downstream tables when schema changes to the base table are introduced. This is a patch in the meantime, while the Snowflake devs work on adding support for automated schema updates in downstream tables.

## testing

The query in this SQL script was run in `synapse_data_warehouse_jmedina` and changes can be viewed there when assuming the `SYSADMIN` role.

1. Confirm that the `project_storage_usage` exists ✔️ 

<img width="548" alt="image" src="https://github.com/user-attachments/assets/17972e77-6d73-4b0d-a7c1-be55a8649ad4" />

2. Confirm that the extra rows in the new `node_latest` are from the few days where the dynamic table was suspended

Query:
```
select *
from synapse_data_warehouse_jmedina.synapse.node_latest jnl
where jnl.id not in (select id from synapse_data_warehouse_dev.synapse.node_latest);
```

<img width="872" alt="image" src="https://github.com/user-attachments/assets/750f1520-f0d1-461d-bd3d-f386e1ee103d" />

No extra rows have been added since the last refresh ✔️ 

3. Confirm that there are no duplicates in the latest table

Query:
```
select count(id), count(distinct id)
from synapse_data_warehouse_jmedina.synapse.node_latest; 
```

<img width="593" alt="image" src="https://github.com/user-attachments/assets/e89b2bda-1648-4df8-b4d3-35df2b76f986" />

No dupes ✔️ 

4. Ensure that the right metadata for each non-null row for `project_storage_usage` is assigned to the right record

Query:
```
SELECT
  SNAPSHOT_DATE,
  PROJECT_STORAGE_USAGE,
  project_id,
  -- Extract the project_id and remove the 'syn' prefix
  SUBSTR(PARSE_JSON(PROJECT_STORAGE_USAGE):projectId::STRING, 4) AS extracted_project_id
FROM
  synapse_data_warehouse_jmedina.synapse.node_latest
WHERE
  project_storage_usage IS NOT NULL
  AND SUBSTR(PARSE_JSON(PROJECT_STORAGE_USAGE):projectId::STRING, 4) = project_id;
```

<img width="594" alt="image" src="https://github.com/user-attachments/assets/5c6172fe-2fb7-4166-9875-177c04f9f47f" />

From visually inspecting the output table, this looks correct ✔️ 