### PR TITLE
[SNOW-239] Comment out redundant statements which set policies

### DIFF
--- a/admin/policies/V1.10.0__initial_policy_document.sql
+++ b/admin/policies/V1.10.0__initial_policy_document.sql
@@ -4,20 +4,37 @@ CREATE PASSWORD POLICY IF NOT EXISTS password_policy
   PASSWORD_MIN_LENGTH = 14
   PASSWORD_MAX_AGE_DAYS = 0;
 
-ALTER ACCOUNT
-  SET PASSWORD POLICY password_policy;
+-- A note on setting policies --
+-- Policies can be set at the account or user level. Snowflake provides
+-- slightly different mechanisms for updating each:
+--
+-- Account:
+-- Normally, an account-level policy must be first UNSET before
+-- we can SET that policy. Optionally, we can specify `... FORCE`
+-- at the end of the ALTER statement to avoid needing to UNSET.
+-- Since we've already set the account parameters contained in this
+-- file and don't want to tempt fate, we leave these commands commented out.
+--
+-- User:
+-- Unlike account-level parameters, there is not even a FORCE
+-- option for these statements, so we must comment these out.
+
+
+-- ALTER ACCOUNT
+--   SET PASSWORD POLICY password_policy;
 CREATE SESSION POLICY IF NOT EXISTS admin_timeout_policy
   SESSION_IDLE_TIMEOUT_MINS = 15
   SESSION_UI_IDLE_TIMEOUT_MINS = 15;
 
-ALTER USER "x.schildwachter@sagebase.org"
-  SET SESSION POLICY admin_timeout_policy;
-ALTER USER "khai.do@sagebase.org"
-  SET SESSION POLICY admin_timeout_policy;
-ALTER USER THOMASYU888
-  SET SESSION POLICY admin_timeout_policy;
-ALTER USER "thomas.yu@sagebase.org"
-  SET SESSION POLICY admin_timeout_policy;
+-- See "A note on setting policies" --
+-- ALTER USER "x.schildwachter@sagebase.org"
+--   SET SESSION POLICY admin_timeout_policy;
+-- ALTER USER "khai.do@sagebase.org"
+--   SET SESSION POLICY admin_timeout_policy;
+-- ALTER USER THOMASYU888
+--   SET SESSION POLICY admin_timeout_policy;
+-- ALTER USER "thomas.yu@sagebase.org"
+--   SET SESSION POLICY admin_timeout_policy;
 
 -- tag service accounts with account type service to not trigger security warning
 CREATE TAG IF NOT EXISTS ACCOUNT_TYPE;
@@ -27,7 +44,6 @@ ALTER USER SNOWFLAKE SET TAG ACCOUNT_TYPE = 'service';
 ALTER USER thomasyu888 SET TAG ACCOUNT_TYPE = 'service';
 
 -- Set up authentication policies
--- SHOW PARAMETERS LIKE 'ENABLE_IDENTIFIER_FIRST_LOGIN' IN ACCOUNT;
 ALTER ACCOUNT SET ENABLE_IDENTIFIER_FIRST_LOGIN = TRUE;
 
 -- Not including CLIENT_TYPES will enable all types for each auth policy
@@ -42,15 +58,17 @@ CREATE AUTHENTICATION POLICY IF NOT EXISTS user_authentication_policy
   AUTHENTICATION_METHODS = ('SAML')
   SECURITY_INTEGRATIONS = ('GOOGLE_SSO');
 
-ALTER ACCOUNT SET AUTHENTICATION POLICY user_authentication_policy;
-ALTER USER "thomas.yu@sagebase.org" SET AUTHENTICATION POLICY admin_authentication_policy;
-ALTER USER "khai.do@sagebase.org" SET AUTHENTICATION POLICY admin_authentication_policy;
+-- See "A note on setting policies" --
+-- ALTER ACCOUNT SET AUTHENTICATION POLICY user_authentication_policy;
 
-ALTER USER RECOVER_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
-ALTER USER DPE_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
-ALTER USER AD_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
-ALTER USER THOMASYU888 SET AUTHENTICATION POLICY service_account_authentication_policy;
-ALTER USER ADMIN_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
-ALTER USER DEVELOPER_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
+-- ALTER USER "thomas.yu@sagebase.org" SET AUTHENTICATION POLICY admin_authentication_policy;
+-- ALTER USER "khai.do@sagebase.org" SET AUTHENTICATION POLICY admin_authentication_policy;
+
+-- ALTER USER RECOVER_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
+-- ALTER USER DPE_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
+-- ALTER USER AD_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
+-- ALTER USER THOMASYU888 SET AUTHENTICATION POLICY service_account_authentication_policy;
+-- ALTER USER ADMIN_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
+-- ALTER USER DEVELOPER_SERVICE SET AUTHENTICATION POLICY service_account_authentication_policy;
 
 ALTER ACCOUNT SET CORTEX_ENABLED_CROSS_REGION = 'ANY_REGION';


### PR DESCRIPTION
Snowflake has some idiosyncracies around running commands like `ALTER... POLICY...`. Since this affects statements in #148 which are attempting to alter account/user policies which are already set to those values, there's no value in jumping through the additional hoops Snowflake sets up to run these types of statements.

I left a comment which explains the reasoning for posterity:
```
-- A note on setting policies --
-- Policies can be set at the account or user level. Snowflake provides
-- slightly different mechanisms for updating each:
--
-- Account:
-- Normally, an account-level policy must be first UNSET before
-- we can SET that policy. Optionally, we can specify `... FORCE`
-- at the end of the ALTER statement to avoid needing to UNSET.
-- Since we've already set the account parameters contained in this
-- file and don't want to tempt fate, we leave these commands commented out.
--
-- User:
-- Unlike account-level parameters, there is not even a FORCE
-- option for these statements, so we must comment these out.
```