### PR TITLE
[SNOW-173] exclude rows with nulls in ASSOCIATION_OBJECT_ID

### DIFF
--- a/.github/workflows/test_with_clone.yaml
+++ b/.github/workflows/test_with_clone.yaml
@@ -81,6 +81,7 @@ jobs:
             - name: Install Snowflake CLI
               uses: Snowflake-Labs/snowflake-cli-action@v1.5
               with:
+                cli-version: "3.7.2"
                 default-config-file-path: ${{ env.SNOWFLAKE_CONFIG_PATH }}
 
             - name: Verify Snowflake CLI installation and connections
@@ -255,6 +256,7 @@ jobs:
           - name: Install Snowflake CLI
             uses: Snowflake-Labs/snowflake-cli-action@v1.5
             with:
+              cli-version: "3.7.2"
               default-config-file-path: ${{ env.SNOWFLAKE_CONFIG_PATH }}
 
           - name: Verify Snowflake CLI installation and connections

--- a/synapse_data_warehouse/synapse_event/dynamic_tables/V2.51.1__update_filedownload_dynamic_table.sql
+++ b/synapse_data_warehouse/synapse_event/dynamic_tables/V2.51.1__update_filedownload_dynamic_table.sql
@@ -33,6 +33,8 @@ CREATE OR REPLACE DYNAMIC TABLE FILEDOWNLOAD
             RECORD_DATE,
             SESSION_ID
         FROM {{database_name}}.SYNAPSE_RAW.FILEDOWNLOAD --noqa: TMP
+        WHERE 
+            ASSOCIATION_OBJECT_ID IS NOT NULL
         QUALIFY
             ROW_NUMBER() OVER (
                 PARTITION BY USER_ID, ASSOCIATION_OBJECT_ID, RECORD_DATE
@@ -42,6 +44,4 @@ CREATE OR REPLACE DYNAMIC TABLE FILEDOWNLOAD
     SELECT 
     *
     FROM 
-        dedup_filedownload
-    WHERE 
-        ASSOCIATION_OBJECT_ID IS NOT NULL;
+        dedup_filedownload;

--- a/synapse_data_warehouse/synapse_event/dynamic_tables/V2.51.1__update_filedownload_dynamic_table.sql
+++ b/synapse_data_warehouse/synapse_event/dynamic_tables/V2.51.1__update_filedownload_dynamic_table.sql
@@ -32,7 +32,8 @@ CREATE OR REPLACE DYNAMIC TABLE FILEDOWNLOAD
             INSTANCE,
             RECORD_DATE,
             SESSION_ID
-        FROM {{database_name}}.SYNAPSE_RAW.FILEDOWNLOAD --noqa: TMP
+        FROM 
+            {{database_name}}.SYNAPSE_RAW.FILEDOWNLOAD --noqa: TMP
         WHERE 
             ASSOCIATION_OBJECT_ID IS NOT NULL
         QUALIFY

--- a/synapse_data_warehouse/synapse_event/dynamic_tables/V2.51.1__update_filedownload_dynamic_table.sql
+++ b/synapse_data_warehouse/synapse_event/dynamic_tables/V2.51.1__update_filedownload_dynamic_table.sql
@@ -1,0 +1,47 @@
+-- Introduce the dynamic table
+USE SCHEMA {{database_name}}.SYNAPSE_EVENT; --noqa: JJ01,PRS,TMP
+
+CREATE OR REPLACE DYNAMIC TABLE FILEDOWNLOAD
+    (
+        TIMESTAMP TIMESTAMP_NTZ(9) COMMENT 'The time when the file download event is pushed to the queue for recording, after generating the pre-signed url.',
+	    USER_ID NUMBER(38,0) COMMENT 'The id of the user who downloaded the file.',
+	    PROJECT_ID NUMBER(38,0) COMMENT 'The unique identifier of the project where the downloaded entity resides. Applicable only for FileEntity and TableEntity.',
+	    FILE_HANDLE_ID NUMBER(38,0) COMMENT 'The unique identifier of the file handle.',
+	    DOWNLOADED_FILE_HANDLE_ID NUMBER(38,0) COMMENT 'The unique identifier of the zip file handle containing the downloaded file when the download is requested as zip/package, otherwise the id of the file handle itself.',
+	    ASSOCIATION_OBJECT_ID NUMBER(38,0) COMMENT 'The unique identifier of the Synapse object (without ''syn'' prefix) that wraps the file.',
+	    ASSOCIATION_OBJECT_TYPE VARCHAR(16777216) COMMENT 'The type of the Synapse object that wraps the file, e.g., FileEntity, TableEntity, WikiAttachment, WikiMarkdown, UserProfileAttachment, MessageAttachment, TeamAttachment.',
+	    STACK VARCHAR(16777216) COMMENT 'The stack (prod, dev) on which the download request was processed.',
+	    INSTANCE VARCHAR(16777216) COMMENT 'The version of the stack that processed the download request.',
+	    RECORD_DATE DATE COMMENT 'The data is partitioned for fast and cost effective queries. The timestamp field is converted into a date and stored in the record_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.',
+	    SESSION_ID VARCHAR(16777216) COMMENT 'The UUID assigned to the API request that triggered this download.  By joining this table with the processedaccessrecord on session_id, more information about the call that triggered this download can be found.'
+    )
+    TARGET_LAG = '1 day'
+    WAREHOUSE = compute_xsmall
+    COMMENT = 'This dynamic table, indexed by the USER_ID, ASSOCIATION_OBJECT_ID and RECORD_DATE columns, contains the most recent file download events.'
+    AS
+    WITH dedup_filedownload AS (
+        SELECT
+            TIMESTAMP,
+            USER_ID,
+            PROJECT_ID,
+            FILE_HANDLE_ID,
+            DOWNLOADED_FILE_HANDLE_ID,
+            ASSOCIATION_OBJECT_ID,
+            ASSOCIATION_OBJECT_TYPE,
+            STACK,
+            INSTANCE,
+            RECORD_DATE,
+            SESSION_ID
+        FROM {{database_name}}.SYNAPSE_RAW.FILEDOWNLOAD --noqa: TMP
+        QUALIFY
+            ROW_NUMBER() OVER (
+                PARTITION BY USER_ID, ASSOCIATION_OBJECT_ID, RECORD_DATE
+                ORDER BY TIMESTAMP DESC, RECORD_DATE DESC
+            ) = 1
+    )
+    SELECT 
+    *
+    FROM 
+        dedup_filedownload
+    WHERE 
+        ASSOCIATION_OBJECT_ID IS NOT NULL;


### PR DESCRIPTION
<!-- REQUIRED -->
<!-- The title of this PR must be prefixed with the Jira ticket -->
<!-- e.g., "[SNOW-404] My brief title" -->
# Problem
There are rows with nulls in ASSOCIATION_OBJECT_ID. 

<!-- REQUIRED -->
Ticket: [SNOW-173](https://sagebionetworks.jira.com/browse/SNOW-173)

# Solution
Add a filter to exclude these rows. 

# Testing
Tested with production data that get the same # total_rows and # distinct_rows. 

<img width="1188" alt="Screenshot 2025-05-16 at 11 50 24 AM" src="https://github.com/user-attachments/assets/7f29ed1a-433b-4139-ab73-eb0311387a86" />


[SNOW-173]: https://sagebionetworks.jira.com/browse/SNOW-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ