### PR TITLE
Add user Karina Leal

### DIFF
--- a/admin/grants.sql
+++ b/admin/grants.sql
@@ -187,6 +187,7 @@ GRANT ROLE DATA_ANALYTICS TO USER "serghei.mangul@sagebase.org";
 GRANT ROLE DATA_ANALYTICS TO USER "jaclyn.beck@sagebase.org";
 GRANT ROLE DATA_ANALYTICS TO USER "ziwei.pan@sagebase.org";
 GRANT ROLE DATA_ANALYTICS TO USER "jessica.britton@sagebase.org";
+GRANT ROLE DATA_ANALYTICS TO USER "karina.leal@sagebase.org";
 GRANT ROLE DATA_ANALYTICS TO USER AD_SERVICE;
 
 // Leaders

--- a/admin/users.sql
+++ b/admin/users.sql
@@ -44,6 +44,7 @@ CREATE USER IF NOT EXISTS "trisha.zintel@sagebase.org";
 CREATE USER IF NOT EXISTS "bishoy.kamel@sagebase.org";
 CREATE USER IF NOT EXISTS "jaclyn.beck@sagebase.org";
 CREATE USER IF NOT EXISTS "jessica.britton@sagebase.org";
+CREATE USER IF NOT EXISTS "karina.leal@sagebase.org";
 
 // NF
 CREATE USER IF NOT EXISTS "anh.nguyet.vu@sagebase.org";


### PR DESCRIPTION
# Problem

Karina Leal needs access to Snowsight so she can view the AD Usage Metrics dashboard.

# Solution

Add Karina Leal as a `DATA_ANALYTICS` user.

# Testing

N/A