### PR TITLE
Drop dummy table from synapse_event

### DIFF
--- a/synapse_data_warehouse/synapse_event/tables/V2.54.0__drop_dummy_table.sql
+++ b/synapse_data_warehouse/synapse_event/tables/V2.54.0__drop_dummy_table.sql
@@ -1,0 +1,3 @@
+USE SCHEMA {{ database_name }}.SYNAPSE_EVENT; --noqa: JJ01,PRS,TMP
+
+DROP TABLE dummy_table;


### PR DESCRIPTION
Just a quick PR to drop the table which we used to test permissions in the `synapse_event` schema.

Depends on #205 (because of schemachange script version)