### PR TITLE
[0.8.0 hotfix] upgrade `node_event` warehouse to compute_medium

### DIFF
--- a/synapse_data_warehouse/synapse_event/dynamic_tables/V2.53.0__node_event_table.sql
+++ b/synapse_data_warehouse/synapse_event/dynamic_tables/V2.53.0__node_event_table.sql
@@ -2,7 +2,7 @@ USE SCHEMA {{ database_name }}.SYNAPSE_EVENT;
 
 CREATE OR REPLACE DYNAMIC TABLE node_event
     TARGET_LAG = '1 day'
-    WAREHOUSE = compute_xsmall
+    WAREHOUSE = compute_medium
     AS
         WITH unique_events AS (
             SELECT

--- a/synapse_data_warehouse/synapse_event/dynamic_tables/V2.56.0__add_objectdownload_event_dynamic_table.sql
+++ b/synapse_data_warehouse/synapse_event/dynamic_tables/V2.56.0__add_objectdownload_event_dynamic_table.sql
@@ -4,16 +4,16 @@ USE SCHEMA {{database_name}}.SYNAPSE_EVENT; --noqa: JJ01,PRS,TMP
 CREATE OR REPLACE DYNAMIC TABLE OBJECTDOWNLOAD_EVENT
     (
         TIMESTAMP TIMESTAMP_NTZ(9) COMMENT 'The time when the file download event is pushed to the queue for recording, after generating the pre-signed url.',
-	USER_ID NUMBER(38,0) COMMENT 'PRIMARY KEY (Composite). The id of the user who downloaded the file.',
-	PROJECT_ID NUMBER(38,0) COMMENT 'The unique identifier of the project where the downloaded entity resides. Applicable only for FileEntity and TableEntity.',
-	FILE_HANDLE_ID NUMBER(38,0) COMMENT 'The unique identifier of the file handle.',
-	DOWNLOADED_FILE_HANDLE_ID NUMBER(38,0) COMMENT 'The unique identifier of the zip file handle containing the downloaded file when the download is requested as zip/package, otherwise the id of the file handle itself.',
-	ASSOCIATION_OBJECT_ID NUMBER(38,0) COMMENT 'PRIMARY KEY (Composite). The unique identifier of the Synapse object (without ''syn'' prefix) that wraps the file.',
-	ASSOCIATION_OBJECT_TYPE VARCHAR(16777216) COMMENT 'PRIMARY KEY (Composite). The type of the Synapse object that wraps the file, e.g., FileEntity, TableEntity, WikiAttachment, WikiMarkdown, UserProfileAttachment, MessageAttachment, TeamAttachment.',
-	STACK VARCHAR(16777216) COMMENT 'The stack (prod, dev) on which the download request was processed.',
-	INSTANCE VARCHAR(16777216) COMMENT 'The version of the stack that processed the download request.',
-	RECORD_DATE DATE COMMENT 'PRIMARY KEY (Composite). The data is partitioned for fast and cost effective queries. The timestamp field is converted into a date and stored in the record_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.',
-	SESSION_ID VARCHAR(16777216) COMMENT 'The UUID assigned to the API request that triggered this download.  By joining this table with the processedaccessrecord on session_id, more information about the call that triggered this download can be found.'
+        USER_ID NUMBER(38,0) COMMENT 'PRIMARY KEY (Composite). The id of the user who downloaded the file.',
+        PROJECT_ID NUMBER(38,0) COMMENT 'The unique identifier of the project where the downloaded entity resides. Applicable only for FileEntity and TableEntity.',
+        FILE_HANDLE_ID NUMBER(38,0) COMMENT 'The unique identifier of the file handle.',
+        DOWNLOADED_FILE_HANDLE_ID NUMBER(38,0) COMMENT 'The unique identifier of the zip file handle containing the downloaded file when the download is requested as zip/package, otherwise the id of the file handle itself.',
+        ASSOCIATION_OBJECT_ID NUMBER(38,0) COMMENT 'PRIMARY KEY (Composite). The unique identifier of the Synapse object (without ''syn'' prefix) that wraps the file.',
+        ASSOCIATION_OBJECT_TYPE VARCHAR(16777216) COMMENT 'PRIMARY KEY (Composite). The type of the Synapse object that wraps the file, e.g., FileEntity, TableEntity, WikiAttachment, WikiMarkdown, UserProfileAttachment, MessageAttachment, TeamAttachment.',
+        STACK VARCHAR(16777216) COMMENT 'The stack (prod, dev) on which the download request was processed.',
+        INSTANCE VARCHAR(16777216) COMMENT 'The version of the stack that processed the download request.',
+        RECORD_DATE DATE COMMENT 'PRIMARY KEY (Composite). The data is partitioned for fast and cost effective queries. The timestamp field is converted into a date and stored in the record_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.',
+        SESSION_ID VARCHAR(16777216) COMMENT 'The UUID assigned to the API request that triggered this download.  By joining this table with the processedaccessrecord on session_id, more information about the call that triggered this download can be found.'
     )
     TARGET_LAG = '1 day'
     WAREHOUSE = compute_xsmall


### PR DESCRIPTION
The `node_event` table took ~40 minutes to build over production data during testing using the `compute_medium` warehouse. It was initially deployed to prod with the `compute_xsmall` warehouse, which caused the create command to timeout:

```
2025-06-12T23:29:05.834771Z [info     ] Applying change script         a_script_name=V2.53.0__node_event_table.sql script_version=2.53.0
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/schemachange/session/SnowflakeSession.py", line 326, in apply_change_script
    self.execute_snowflake_query(query=script_content, logger=logger)
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/schemachange/session/SnowflakeSession.py", line 116, in execute_snowflake_query
    raise e
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/schemachange/session/SnowflakeSession.py", line 109, in execute_snowflake_query
    res = self.con.execute_string(query)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/snowflake/connector/connection.py", line 1017, in execute_string
    ret = list(stream_generator)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/snowflake/connector/connection.py", line 1035, in execute_stream
    cur.execute(sql, _is_put_get=is_put_or_get, **kwargs)
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/snowflake/connector/cursor.py", line 1134, in execute
    Error.errorhandler_wrapper(self.connection, self, error_class, errvalue)
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/snowflake/connector/errors.py", line 279, in errorhandler_wrapper
    handed_over = Error.hand_to_other_handler(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/snowflake/connector/errors.py", line 334, in hand_to_other_handler
    cursor.errorhandler(connection, cursor, error_class, error_value)
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/snowflake/connector/errors.py", line 210, in default_errorhandler
    raise error_class(
snowflake.connector.errors.ProgrammingError: 000630 ([57](https://github.com/Sage-Bionetworks/snowflake/actions/runs/15622688127/job/44010879503#step:4:58)014): Statement reached its statement or warehouse timeout of 10,800 second(s) and was canceled.
```

Rather than modifying the timeout, I'm updating the warehouse of the `node_event` table – a multi-hour build using the smaller warehouse is not desirable, either.

I also updated some space/tab issues in another file.