### PR TITLE
[SNOW-296] Upgrade WH in V2.62.0__file_event_table.sql

### DIFF
--- a/synapse_data_warehouse/synapse_event/dynamic_tables/V2.62.0__file_event_table.sql
+++ b/synapse_data_warehouse/synapse_event/dynamic_tables/V2.62.0__file_event_table.sql
@@ -2,7 +2,7 @@ USE SCHEMA {{database_name}}.synapse_event; --noqa: JJ01,PRS,TMP
 
 CREATE OR REPLACE DYNAMIC TABLE FILE_EVENT
     TARGET_LAG = '1 day'
-    WAREHOUSE = compute_xsmall
+    WAREHOUSE = compute_medium
     AS 
     WITH dedup_filesnapshots AS (
         SELECT


### PR DESCRIPTION
<!-- REQUIRED -->
<!-- The title of this PR must be prefixed with the Jira ticket -->
<!-- e.g., "[SNOW-404] My brief title" -->
# Problem
<!-- Describe the specific technical problem that this PR solves. -->

<!-- REQUIRED -->
Ticket: [SNOW-296](https://sagebionetworks.jira.com/browse/SNOW-296)

Failure to deploy this change into `main` because it exceeded the `COMPUTE_XSMALL` warehouse time cap. [See here](https://github.com/Sage-Bionetworks/snowflake/actions/runs/16891795579) for more.

**Discussion**: The reason why we probably didn't see this issue when deploying to `dev` is because the dev stack data is much smaller in size. As a low priority ticket, we could write a set of guidelines for when we should upgrade to `COMPUTE_MEDIUM` based on query complexity, table size, etc.

# Solution

Update the warehouse to `COMPUTE_MEDIUM` for this script.

# Testing

CI/CD deployed a test db successfully, but this isn't entirely helpful since the clone is built off `dev` which isn't truly representative of the data volume we have in `prod`

[SNOW-296]: https://sagebionetworks.jira.com/browse/SNOW-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ