### PR TITLE
[SNOW-336] Compare dates in `SYNAPSE` table DDL and update window in acl_latest

### DIFF
--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.0__acl_latest_datetime_and_window.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.0__acl_latest_datetime_and_window.sql
@@ -1,6 +1,5 @@
 USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
 
-
 create or replace dynamic table ACL_LATEST(
 	CHANGE_TIMESTAMP COMMENT 'The timestamp when the change (created/updated) on an access control list was pushed to the queue for snapshotting.',
 	CHANGE_TYPE COMMENT 'The type of change that occurred on the access control list, e.g., CREATE, UPDATE.',

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.10__team_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.10__team_latest_date_comparison.sql
@@ -1,0 +1,35 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table TEAM_LATEST(
+	CHANGE_TYPE COMMENT 'The type of change that occurred to the team, e.g., CREATE, UPDATE.',
+	CHANGE_TIMESTAMP COMMENT 'The time when any change to the team was made (e.g. create, update or a change to its members).',
+	CHANGE_USER_ID COMMENT 'The unique identifier of the user who made the change to the team.',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken (It is usually after the change happened).',
+	ID COMMENT 'The unique identifier of the team.',
+	NAME COMMENT 'The name of the team.',
+	CAN_PUBLIC_JOIN COMMENT 'If true, a user can join the team without approval of a team manager.',
+	CREATED_ON COMMENT 'The creation time of the team.',
+	CREATED_BY COMMENT 'The unique identifier of the user who created the team.',
+	MODIFIED_ON COMMENT 'The time when the team was last modified.',
+	MODIFIED_BY COMMENT 'The unique identifier of the user who last modified the team.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This dynamic table, indexed by ID, contains the latest snapshot of Synapse teams. It is derived from TEAMSNAPSHOTS raw data and provides deduplicated team information. The table is refreshed daily and contains only the most recent team entries for each ID from the past 30 days. Each row represents a specific team with its current state and membership configuration.'
+ as
+        WITH RANKED_NODES AS (
+            SELECT
+                *,
+                "row_number"()
+                    OVER (
+                        PARTITION BY ID
+                        ORDER BY CHANGE_TIMESTAMP DESC, SNAPSHOT_TIMESTAMP DESC
+                    )
+                    AS N
+            FROM {{database_name}}.SYNAPSE_RAW.TEAMSNAPSHOTS --noqa: TMP
+            WHERE
+                SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '30 DAYS'
+            QUALIFY
+                N=1
+        )
+        SELECT * EXCLUDE N
+        FROM RANKED_NODES;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.1__teammember_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.1__teammember_latest_date_comparison.sql
@@ -1,0 +1,37 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table TEAMMEMBER_LATEST(
+	CHANGE_TYPE COMMENT 'The type of change that occurred to the member of team, e.g., CREATE, UPDATE (Snapshotting does not capture DELETE change).',
+	CHANGE_TIMESTAMP COMMENT 'The time when any change to the team was made (e.g. update of the team or a change to its members).',
+	CHANGE_USER_ID COMMENT 'The unique identifier of the user who made the change to the team member.',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken (It is usually after the change happened).',
+	TEAM_ID COMMENT 'The unique identifier of the team.',
+	MEMBER_ID COMMENT 'The unique identifier of the member of the team. The member is a Synapse user.',
+	IS_ADMIN COMMENT 'If true, then the member is manager of the team.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This dynamic table, indexed by the TEAM_ID and MEMBER_ID columns, contains the most recent snapshot of team members. Since snapshotting does not capture DELETE events, records may still be retained if a team member was deleted within the past 14 days.'
+ as 
+    WITH dedup_teammembers AS (
+        SELECT
+	    CHANGE_TYPE,
+	    CHANGE_TIMESTAMP,
+	    CHANGE_USER_ID, 
+	    SNAPSHOT_TIMESTAMP, 
+	    TEAM_ID, 
+	    MEMBER_ID, 
+	    IS_ADMIN, 
+	    SNAPSHOT_DATE 
+        FROM {{database_name}}.SYNAPSE_RAW.teammembersnapshots --noqa: TMP
+        WHERE
+            SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '14 days'
+        QUALIFY
+            ROW_NUMBER() OVER (
+                PARTITION BY TEAM_ID, MEMBER_ID
+                ORDER BY CHANGE_TIMESTAMP DESC, SNAPSHOT_TIMESTAMP DESC
+            ) = 1
+    )
+    SELECT 
+	*
+    FROM 
+        dedup_teammembers;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.2__file_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.2__file_latest_date_comparison.sql
@@ -1,0 +1,63 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table FILE_LATEST(
+	CHANGE_TYPE COMMENT 'The type of change that occurred on the file handle, e.g., CREATE, UPDATE, DELETE.',
+	CHANGE_TIMESTAMP COMMENT 'The time when the change (created/updated/deleted) on the file is pushed to the queue for snapshotting.',
+	CHANGE_USER_ID COMMENT 'The unique identifier of the user who made the change to the file.',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken (It is usually after the change happened).',
+	ID COMMENT 'The unique identifier of the file handle.',
+	CREATED_BY COMMENT 'The unique identifier of the user who created the file handle.',
+	CREATED_ON COMMENT 'The creation timestamp of the file handle.',
+	MODIFIED_ON COMMENT 'The most recent change time of the file handle.',
+	CONCRETE_TYPE COMMENT 'The type of the file handle. Allowed file handles are: S3FileHandle, ProxyFileHandle, ExternalFileHandle, ExternalObjectStoreFileHandle, GoogleCloudFileHandle.',
+	CONTENT_MD5 COMMENT 'The md5 hash (using MD5 algorithm) of the file referenced by the file handle.',
+	CONTENT_TYPE COMMENT 'Metadata about the content of the file, e.g., application/json, application/zip, application/octet-stream.',
+	FILE_NAME COMMENT 'The name of the file referenced by the file handle.',
+	STORAGE_LOCATION_ID COMMENT 'The identifier of the environment, where the physical files are stored.',
+	CONTENT_SIZE COMMENT 'The size of the file referenced by the file handle.',
+	BUCKET COMMENT 'The bucket where the file is physically stored. Applicable for s3 and GCP, otherwise empty.',
+	KEY COMMENT 'The key name uniquely identifies the object (file) in the bucket.',
+	PREVIEW_ID COMMENT 'The identifier of the file handle that contains a preview of the file referenced by this file handle.',
+	IS_PREVIEW COMMENT 'If true, the file referenced by this file handle is a preview of another file.',
+	STATUS COMMENT 'The availability status of the file referenced by the file handle. AVAILABLE: accessible via Synapse; UNLINKED: not referenced by Synapse and therefore available for garbage collection; ARCHIVED: the file has been garbage collected.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This dynamic table, indexed by the ID column, contains the most recent snapshot of file handles.'
+ as 
+    WITH dedup_filesnapshots AS (
+        SELECT
+            *
+        FROM {{database_name}}.SYNAPSE_RAW.FILESNAPSHOTS --noqa: TMP
+        WHERE
+            SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '30 days' AND NOT IS_PREVIEW
+        QUALIFY
+            ROW_NUMBER() OVER (
+                PARTITION BY ID
+                ORDER BY CHANGE_TIMESTAMP DESC, SNAPSHOT_TIMESTAMP DESC
+            ) = 1
+    )
+    SELECT 
+        CHANGE_TYPE,
+        CHANGE_TIMESTAMP,
+        CHANGE_USER_ID,
+        SNAPSHOT_TIMESTAMP,
+        ID,
+        CREATED_BY,
+        CREATED_ON,
+        MODIFIED_ON,
+        CONCRETE_TYPE,
+        CONTENT_MD5,
+        CONTENT_TYPE,
+        FILE_NAME,
+        STORAGE_LOCATION_ID,
+        CONTENT_SIZE,
+        BUCKET,
+        KEY,
+        PREVIEW_ID,
+        IS_PREVIEW,
+        STATUS,
+        SNAPSHOT_DATE
+    FROM 
+        dedup_filesnapshots
+    WHERE
+        CHANGE_TYPE != 'DELETE';

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.3__node_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.3__node_latest_date_comparison.sql
@@ -1,0 +1,97 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table NODE_LATEST(
+	CHANGE_TYPE COMMENT 'The type of change that occurred on the node, e.g., CREATE, UPDATE.',
+	CHANGE_TIMESTAMP COMMENT 'The time when the change (created/updated) on the node is pushed to the queue for snapshotting.',
+	CHANGE_USER_ID COMMENT 'The unique identifier of the user who made the change to the node.',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken. (It is usually after the change happened).',
+	ID COMMENT 'The unique identifier of the node.',
+	BENEFACTOR_ID COMMENT 'The identifier of the (ancestor) node which provides the permissions that apply to this node. Can be the id of the node itself.',
+	PROJECT_ID COMMENT 'The project where the node resides.',
+	PARENT_ID COMMENT 'The unique identifier of the parent in the node hierarchy.',
+	NODE_TYPE COMMENT 'The type of the node. Allowed node types are: project, folder, file, table, link, entityview, dockerrepo, submissionview, dataset, datasetcollection, materializedview, virtualtable.',
+	CREATED_ON COMMENT 'The creation time of the node.',
+	CREATED_BY COMMENT 'The unique identifier of the user who created the node.',
+	MODIFIED_ON COMMENT 'The most recent change time of the node.',
+	MODIFIED_BY COMMENT 'The unique identifier of the user who last modified the node.',
+	VERSION_NUMBER COMMENT 'The version of the node on which the change occurred, if applicable.',
+	FILE_HANDLE_ID COMMENT 'The unique identifier of the file handle if the node is a file, null otherwise.',
+	NAME COMMENT 'The name of the node.',
+	IS_PUBLIC COMMENT 'If true, READ permission is granted to all the Synapse users, including the anonymous user, at the time of the snapshot.',
+	IS_CONTROLLED COMMENT 'If true, an access requirement managed by the ACT is set on the node.',
+	IS_RESTRICTED COMMENT 'If true, a terms-of-use access requirement is set on the node.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.',
+	EFFECTIVE_ARS COMMENT 'The list of access requirement ids that apply to the entity at the time the snapshot was taken.',
+	ANNOTATIONS COMMENT 'The json representation of the entity annotations assigned by the user.',
+	DERIVED_ANNOTATIONS COMMENT 'The json representation of the entity annotations that were derived by the schema of the entity.',
+	VERSION_COMMENT COMMENT 'A short description assigned to this node version.',
+	VERSION_LABEL COMMENT 'A short label assigned to this node version.',
+	ALIAS COMMENT 'An alias assigned to a project entity if present.',
+	ACTIVITY_ID COMMENT 'The reference to the id of an activity assigned to the node.',
+	COLUMN_MODEL_IDS COMMENT 'For entities that define a table schema (e.g. table, views etc), the list of column ids assigned to the schema.',
+	SCOPE_IDS COMMENT 'For entities that define a scope (e.g. entity views, submission views etc), the list of entity ids included in the scope.',
+	ITEMS COMMENT 'For entities that define a fixed list of entity references (e.g. dataset, dataset collections), the list of entity references included in the scope.',
+	REFERENCE COMMENT 'For Link entities, the reference to the linked target.',
+	IS_SEARCH_ENABLED COMMENT 'For Table like entities (e.g. EntityView, MaterializedView etc), defines if full text search is enabled on those entities.',
+	DEFINING_SQL COMMENT 'For tables that are driven by a synapse SQL query (e.g. MaterializedView, VirtualTable), defines the underlying SQL query.',
+	INTERNAL_ANNOTATIONS COMMENT 'The json representation of the entity internal annotations that are used to store additional data about different types of entity (e.g. dataset checksum, size, count).',
+	VERSION_HISTORY COMMENT 'The list of entity versions, at the time of the snapshot.',
+	PROJECT_STORAGE_USAGE COMMENT 'The storage usage information for the project, including size and count metrics.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This dynamic table, indexed by ID, contains the latest snapshot of Synapse nodes (projects, files, folders, tables, etc.). It is derived from NODESNAPSHOTS raw data and provides deduplicated node information. The table is refreshed daily and contains only the most recent node entries for each ID from the past 30 days. Each row represents a specific Synapse node with its current state and metadata.'
+ as
+        WITH latest_unique_rows AS (
+            SELECT
+                CHANGE_TYPE,
+                CHANGE_TIMESTAMP,
+                CHANGE_USER_ID,
+                SNAPSHOT_TIMESTAMP,
+                ID,
+                BENEFACTOR_ID,
+                PROJECT_ID,
+                PARENT_ID,
+                NODE_TYPE,
+                CREATED_ON,
+                CREATED_BY,
+                MODIFIED_ON,
+                MODIFIED_BY,
+                VERSION_NUMBER,
+                FILE_HANDLE_ID,
+                NAME,
+                IS_PUBLIC,
+                IS_CONTROLLED,
+                IS_RESTRICTED,
+                SNAPSHOT_DATE,
+                EFFECTIVE_ARS,
+                ANNOTATIONS,
+                DERIVED_ANNOTATIONS,
+                VERSION_COMMENT,
+                VERSION_LABEL,
+                ALIAS,
+                ACTIVITY_ID,
+                COLUMN_MODEL_IDS,
+                SCOPE_IDS,
+                ITEMS,
+                REFERENCE,
+                IS_SEARCH_ENABLED,
+                DEFINING_SQL,
+                INTERNAL_ANNOTATIONS,
+                VERSION_HISTORY,
+                PROJECT_STORAGE_USAGE
+            FROM
+                {{database_name}}.synapse_raw.nodesnapshots --noqa: TMP
+            WHERE
+                SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '30 DAYS'
+            QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY id
+                    ORDER BY change_timestamp DESC, snapshot_timestamp DESC
+                ) = 1
+        )
+        SELECT
+            *
+        FROM
+            latest_unique_rows
+        WHERE
+            NOT (CHANGE_TYPE = 'DELETE' OR BENEFACTOR_ID = '1681355' OR PARENT_ID = '1681355') -- 1681355 is the synID of the trash can on Synapse
+        ORDER BY
+            latest_unique_rows.id ASC;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.4__userprofile_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.4__userprofile_latest_date_comparison.sql
@@ -1,0 +1,44 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table USERPROFILE_LATEST(
+	CHANGE_TYPE COMMENT 'The type of change that occurred to the user profile, e.g., CREATE, UPDATE (Snapshotting does not capture DELETE change).',
+	CHANGE_TIMESTAMP COMMENT 'The time when any change to the user profile was made (e.g. create or update).',
+	CHANGE_USER_ID COMMENT 'The unique identifier of the user who made the change to the user profile.',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken (It is usually after the change happened).',
+	ID COMMENT 'The unique identifier of the user.',
+	USER_NAME COMMENT 'The Synapse username.',
+	FIRST_NAME COMMENT 'The first name of the user.',
+	LAST_NAME COMMENT 'The last name of the user.',
+	EMAIL COMMENT 'The primary email of the user.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.',
+	CREATED_ON COMMENT 'The creation time of the user profile.',
+	IS_TWO_FACTOR_AUTH_ENABLED COMMENT 'Indicates if the user had two factor authentication enabled when the snapshot was captured.',
+	TOS_AGREEMENTS COMMENT 'Contains the list of all the term of service that the user agreed to, with their agreed on date and version.',
+	LOCATION COMMENT 'The location of the user.',
+	COMPANY COMMENT 'The company where the user works.',
+	POSITION COMMENT 'The position of the user in the company.',
+	INDUSTRY COMMENT 'The industry/discipline that this person is associated with.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This dynamic table, indexed by the ID column, contains the most recent snapshot of user profiles. Since snapshotting does not capture DELETE events, records may still be retained if a user was deleted within the past 14 days.'
+ as 
+    WITH dedup_userprofile AS (
+        SELECT
+            *
+        FROM {{database_name}}.SYNAPSE_RAW.USERPROFILESNAPSHOT --noqa: TMP
+        WHERE
+            SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '14 days'
+        QUALIFY
+            ROW_NUMBER() OVER (
+                PARTITION BY ID
+                ORDER BY CHANGE_TIMESTAMP DESC, SNAPSHOT_TIMESTAMP DESC
+            ) = 1
+    )
+    SELECT 
+        * exclude (LOCATION, COMPANY, POSITION, INDUSTRY), 
+        -- TODO: Need to revisit this section after the mixture of NULL and empty strings issue being resolved in https://sagebionetworks.jira.com/browse/SWC-7215
+        NULLIF(LOCATION, '') AS LOCATION, 
+        NULLIF(COMPANY, '') AS COMPANY, 
+        NULLIF(POSITION, '') AS POSITION, 
+        NULLIF(INDUSTRY, '') AS INDUSTRY, 
+    FROM 
+     dedup_userprofile;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.5__certifiedquizquestion_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.5__certifiedquizquestion_latest_date_comparison.sql
@@ -1,0 +1,44 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table USERPROFILE_LATEST(
+	CHANGE_TYPE COMMENT 'The type of change that occurred to the user profile, e.g., CREATE, UPDATE (Snapshotting does not capture DELETE change).',
+	CHANGE_TIMESTAMP COMMENT 'The time when any change to the user profile was made (e.g. create or update).',
+	CHANGE_USER_ID COMMENT 'The unique identifier of the user who made the change to the user profile.',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken (It is usually after the change happened).',
+	ID COMMENT 'The unique identifier of the user.',
+	USER_NAME COMMENT 'The Synapse username.',
+	FIRST_NAME COMMENT 'The first name of the user.',
+	LAST_NAME COMMENT 'The last name of the user.',
+	EMAIL COMMENT 'The primary email of the user.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.',
+	CREATED_ON COMMENT 'The creation time of the user profile.',
+	IS_TWO_FACTOR_AUTH_ENABLED COMMENT 'Indicates if the user had two factor authentication enabled when the snapshot was captured.',
+	TOS_AGREEMENTS COMMENT 'Contains the list of all the term of service that the user agreed to, with their agreed on date and version.',
+	LOCATION COMMENT 'The location of the user.',
+	COMPANY COMMENT 'The company where the user works.',
+	POSITION COMMENT 'The position of the user in the company.',
+	INDUSTRY COMMENT 'The industry/discipline that this person is associated with.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This dynamic table, indexed by the ID column, contains the most recent snapshot of user profiles. Since snapshotting does not capture DELETE events, records may still be retained if a user was deleted within the past 14 days.'
+ as 
+    WITH dedup_userprofile AS (
+        SELECT
+            *
+        FROM {{database_name}}.SYNAPSE_RAW.USERPROFILESNAPSHOT --noqa: TMP
+        WHERE
+            SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '14 days'
+        QUALIFY
+            ROW_NUMBER() OVER (
+                PARTITION BY ID
+                ORDER BY CHANGE_TIMESTAMP DESC, SNAPSHOT_TIMESTAMP DESC
+            ) = 1
+    )
+    SELECT 
+        * exclude (LOCATION, COMPANY, POSITION, INDUSTRY), 
+        -- TODO: Need to revisit this section after the mixture of NULL and empty strings issue being resolved in https://sagebionetworks.jira.com/browse/SWC-7215
+        NULLIF(LOCATION, '') AS LOCATION, 
+        NULLIF(COMPANY, '') AS COMPANY, 
+        NULLIF(POSITION, '') AS POSITION, 
+        NULLIF(INDUSTRY, '') AS INDUSTRY, 
+    FROM 
+     dedup_userprofile;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.6__projectsetting_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.6__projectsetting_latest_date_comparison.sql
@@ -1,0 +1,35 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table PROJECTSETTING_LATEST(
+	CHANGE_TIMESTAMP COMMENT 'The time when a project settings change (created/updated) occurred.',
+	CHANGE_TYPE COMMENT 'The type of change that occurred on the project settings, e.g., CREATE, UPDATE, DELETE.',
+	CHANGE_USER_ID COMMENT 'The id of the user that created, updated the project settings being snapshotted.',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken. Snapshots are taken after each change event and periodically.',
+	ID COMMENT 'The unique identifier of the project setting.',
+	CONCRETE_TYPE COMMENT 'The type of project settings. See https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/project/ProjectSetting.html.',
+	PROJECT_ID COMMENT 'The ID of the project to which the settings apply.',
+	SETTINGS_TYPE COMMENT 'The short type of the project settings. See https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/project/ProjectSetting.html.',
+	ETAG COMMENT 'UUID issued each time the project settings changes.',
+	LOCATIONS COMMENT 'The storage location IDs associated with the project setting.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This dynamic table, indexed by ID, contains the latest snapshot of project settings for Synapse projects. It is derived from PROJECTSETTINGSNAPSHOTS raw data and provides deduplicated project settings information. The table is refreshed daily and contains only the most recent settings entries for each project ID from the past 14 days. Each row represents a specific project setting with its current configuration.'
+ as
+        WITH latest_unique_rows AS (
+            SELECT
+                *
+            FROM
+                {{database_name}}.synapse_raw.projectsettingsnapshots --noqa: TMP
+            WHERE
+                SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '14 DAYS'
+            QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY id
+                    ORDER BY change_timestamp DESC, snapshot_timestamp DESC
+                ) = 1
+        )
+        SELECT
+            *
+        FROM
+            latest_unique_rows
+        ORDER BY
+            latest_unique_rows.id ASC;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.7__accessrequirement_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.7__accessrequirement_latest_date_comparison.sql
@@ -1,0 +1,57 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table ACCESSREQUIREMENT_LATEST(
+	CHANGE_TIMESTAMP COMMENT 'The time when the change (created/updated) on an access requirement is pushed to the queue. DELETE change types are not currently captured.',
+	CHANGE_TYPE COMMENT 'The type of change that occurred on the access requirement, e.g., CREATE, UPDATE.',
+	CHANGE_USER_ID COMMENT 'The id of the user that created or updated this access requirement snapshot',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken (It is usually after the change happened).',
+	ID COMMENT 'The unique identifier of the access requirement.',
+	VERSION_NUMBER COMMENT 'The version of the access requirement. Each time an access requirement is updated a new version is issued.',
+	NAME COMMENT 'The name assigned to the access requirement.',
+	DESCRIPTION COMMENT 'The description assigned to the access requirement.',
+	CREATED_BY COMMENT 'The id of the user that created the access requirement.',
+	MODIFIED_BY COMMENT 'The id of the user that modified the access requirement.',
+	CREATED_ON COMMENT 'The creation time of the access requirement.',
+	MODIFIED_ON COMMENT 'The most recent change time of the access requirement.',
+	ACCESS_TYPE COMMENT 'The type of access this access requirement applies to, currently supports only DOWNLOAD (for entities) and PARTICIPATE (for teams).',
+	CONCRETE_TYPE COMMENT 'The type of access requirement. See https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/AccessRequirement.html.',
+	SUBJECTS_DEFINED_BY_ANNOTATIONS COMMENT 'True if the subjects of the access requirement are automatically inferred by derived annotations. If true the subjectIds will be empty.\"',
+	SUBJECTS_IDS COMMENT 'The list of objects controlled by this access requirement. If the access_type is DOWNLOAD each element will be an ENTITY, If the access_type is PARTICIPATE each element will be a TEAM. This list is empty if subjects_defined_by_annotations is true.',
+	IS_CERTIFIED_USER_REQUIRED COMMENT 'True if the user certification is required to fulfill the access requirement. Applies only to ManagedACTAccessRequirement and SelfSignAccessRequirement.',
+	IS_VALIDATED_PROFILE_REQUIRED COMMENT 'True if the profile validation is required to fulfill the access requirement. Applies only to ManagedACTAccessRequirement and SelfSignAccessRequirement.',
+	IS_DUC_REQUIRED COMMENT 'True if a Data Use Certificate (DUC) is required to fulfill the access requirement. Applies only to ManagedACTAccessRequirement.',
+	IS_IRB_APPROVAL_REQUIRED COMMENT 'True if an Institutional Review Board (IRB) approval document is required to fulfill the access requirement. Applies only to ManagedACTAccessRequirement.',
+	ARE_OTHER_ATTACHMENTS_REQUIRED COMMENT 'True if additional attachment(s) are required to fulfill the access requirement. Applies only to ManagedACTAccessRequirement.',
+	IS_IDU_PUBLIC COMMENT 'True if the Intended Data Use Statements submitted to gain access to the data will be presented to public. Applies only to ManagedACTAccessRequirement.',
+	IS_IDU_REQUIRED COMMENT 'True the Intended Data Use Statement for a research project is required to fulfill the access requirement. Applies only to ManagedACTAccessRequirement.',
+	IS_TWO_FA_REQUIRED COMMENT 'True if two factor authentication is required to fulfill the access requirement. Applies only to ManagedACTAccessRequirement.',
+	DUC_TEMPLATE_FILE_HANDLE_ID COMMENT 'The id of the file handle containing the DUC template (if a DUC is required) that needs to be filled and signed by users to fulfill the access requirement. Applies only to ManagedACTAccessRequirement.',
+	EXPIRATION_PERIOD COMMENT 'The amount in milliseconds that an approval of this access requirement is valid for. Applies only to ManagedACTAccessRequirement.',
+	TERMS_OF_USER COMMENT 'The terms of use text. Applies only to TermsOfUseAccessRequirement.',
+	ACT_CONTACT_INFO COMMENT 'Information on how to contact the Synapse ACT for access approval (external to Synapse). Applies only to ACTAccessRequirement.',
+	OPEN_JIRA_ISSUE COMMENT 'Flag that indicate if a JIRA issue needs to be opened in addition to follow the act_contact_info . Applies only to ACTAccessRequirement.',
+	JIRA_KEY COMMENT 'The key of the jira issue created for this Access Requirement. Applies only to LockAccessRequirement.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This table, indexed by ID, contains the latest snapshot of access requirements.'
+ as
+        WITH latest_unique_rows AS (
+            SELECT
+                *
+            FROM
+                {{database_name}}.synapse_raw.accessrequirementsnapshots --noqa: TMP
+            WHERE
+                SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '14 DAYS'
+            QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY id
+                    ORDER BY change_timestamp DESC, snapshot_timestamp DESC
+                ) = 1
+        )
+        SELECT
+            *
+        FROM
+            latest_unique_rows
+        WHERE
+            CHANGE_TYPE != 'DELETE'
+        ORDER BY
+            latest_unique_rows.id ASC;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.8__usergroup_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.8__usergroup_latest_date_comparison.sql
@@ -1,0 +1,31 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table USERGROUP_LATEST(
+	CHANGE_TYPE COMMENT 'The type of change that occurred to the user-group, e.g., CREATE, UPDATE.',
+	CHANGE_TIMESTAMP COMMENT 'The time when the change (creation/update) to the user-group is pushed to the queue for snapshotting.',
+	CHANGE_USER_ID COMMENT 'The unique identifier of the user who made the change to the user-group.',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken (It is usually after the change happened).',
+	ID COMMENT 'The unique identifier of user or group.',
+	IS_INDIVIDUAL COMMENT 'If true, then this user group is an individual user not a team.',
+	CREATED_ON COMMENT 'The creation time of the user or group.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This dynamic table, indexed by ID, contains the latest snapshot of Synapse principals (individual users and groups of users). It is derived from USERGROUPSNAPSHOTS raw data and provides deduplicated user group information. The table is refreshed daily and contains only the most recent entries for each ID from the past 14 days. Each row represents a specific principal (individual user or group) with its current state.'
+ as
+        WITH dedup_usergroup AS (
+            SELECT
+                *,
+                "row_number"()
+                    OVER (
+                        PARTITION BY ID
+                        ORDER BY CHANGE_TIMESTAMP DESC, SNAPSHOT_TIMESTAMP DESC
+                    )
+                    AS N
+            FROM {{database_name}}.SYNAPSE_RAW.USERGROUPSNAPSHOTS --noqa: TMP
+            WHERE 
+                SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '14 days'
+            QUALIFY
+                N=1
+        )
+        SELECT * EXCLUDE N
+        FROM dedup_usergroup;

--- a/synapse_data_warehouse/synapse/dynamic_tables/V2.63.9__verificationsubmission_latest_date_comparison.sql
+++ b/synapse_data_warehouse/synapse/dynamic_tables/V2.63.9__verificationsubmission_latest_date_comparison.sql
@@ -1,0 +1,34 @@
+USE SCHEMA {{database_name}}.synapse; --noqa: JJ01,PRS,TMP
+
+create or replace dynamic table VERIFICATIONSUBMISSION_LATEST(
+	CHANGE_TIMESTAMP COMMENT 'The time when the change (created/updated) on a submission is pushed to the queue for snapshotting.',
+	CHANGE_TYPE COMMENT 'The type of change that occurred on the submission, e.g., CREATE, UPDATE.',
+	SNAPSHOT_TIMESTAMP COMMENT 'The time when the snapshot was taken (It is usually after the change happened).',
+	ID COMMENT 'The unique identifier of the submission.',
+	CREATED_ON COMMENT 'The creation time of the submission.',
+	CREATED_BY COMMENT 'The unique identifier of the user who created the submission.',
+	STATE_HISTORY COMMENT 'The sequence of submission states (SUBMITTED, REJECTED, APPROVED) for the submission.',
+	SNAPSHOT_DATE COMMENT 'The data is partitioned for fast and cost effective queries. The snapshot_timestamp field is converted into a date and stored in the snapshot_date field for partitioning. The date should be used as a condition (WHERE CLAUSE) in the queries.'
+) target_lag = '1 day' refresh_mode = AUTO initialize = ON_CREATE warehouse = COMPUTE_XSMALL
+ COMMENT='This dynamic table, indexed by ID, contains the latest snapshot of user verification submissions by ACT. It is derived from VERIFICATIONSUBMISSIONSNAPSHOTS raw data and provides deduplicated verification submission information. The table is refreshed daily and contains only the most recent submission entries for each ID from the past 14 days. Each row represents a specific verification submission with its current state and history.'
+ as
+    -- We deduplicate simply by selecting the latest record for each
+    -- verification submission ID...
+    WITH latest_unique_rows AS (
+        SELECT
+            verificationsubmissionsnapshots.*,
+        FROM
+            {{database_name}}.synapse_raw.verificationsubmissionsnapshots --noqa: TMP
+        WHERE
+            SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL '14 DAYS'
+        QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY id
+                ORDER BY change_timestamp DESC, snapshot_timestamp DESC
+            ) = 1
+    )
+    SELECT
+        *
+    FROM
+        latest_unique_rows
+    ORDER BY
+        latest_unique_rows.id ASC;


### PR DESCRIPTION
<!-- REQUIRED -->
<!-- The title of this PR must be prefixed with the Jira ticket -->
<!-- e.g., "[SNOW-404] My brief title" -->
# Problem
<!-- Describe the specific technical problem that this PR solves. -->

<!-- REQUIRED -->
Ticket: [SNOW-336](https://sagebionetworks.jira.com/browse/SNOW-336)

<!-- OPTIONAL -->
<!-- A brief description of the *technical* or *implementation* aspects of the problem -->
<!-- (Most or all contextual information about the problem should already be in Jira) -->

# Solution
<!-- Describe the specific technical solution that this PR provides -->

<!-- REQUIRED -->
<!-- For each of the acceptance criteria specified in the Jira ticket, describe how this criterion was addressed. -->
<!-- If you feel that it helps with clarity, provide links to specific lines within your changes. -->
✅  update the DDL for `acl_latest` to compare dates appropriately
✅  EXTRA CREDIT: update the partition to include `owner_type`, since owner IDs are not necessarily unique across owner types
✅   grep for uses of `current_timestamp` in other tables which perform a similarly imprecise comparison

<!-- OPTIONAL -->
<!-- Describe any additional changes made that aren't relevant to the acceptance criteria. -->
<!-- Provide additional information that could help reviewers understand these changes and any potential side effects. -->
In a few cases, I found that we were comparing datetimes with dates, e.g.:
```
...
WHERE snapshot_date >= current_timestamp - interval '14 days';
```

Although for our snapshot tables more generally, I consistently found that we were filtering snapshots based on their _timestamp_, rather than their date, e.g.:
```
...
WHERE SNAPSHOT_TIMESTAMP >= CURRENT_TIMESTAMP - INTERVAL...
```
this was problematic, because it conflated the dynamic table build time with the snapshot time. That is, while platform guarantees us that snapshots are taken regularly every 7-14 days, they don't guarantee this down to the second. If we build our dynamic tables at 11 PM _today_, and we want to deduplicate among snapshots within the last 14 days, we ignore any snapshots which were taken before 11 PM on the "14th day ago" using this logic. This can mean dropping unique records entirely if, as happened with the records described in the Jira ticket description, we don't have a more recent snapshot of this record.

The proper comparison is:
```
...
WHERE SNAPSHOT_DATE >= CURRENT_DATE - INTERVAL...
```

As a result, I had to modify significantly more tables than I had initially expected.

<!-- LINKING TO CODE -->
<!-- See official documentation -->
<!-- https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet -->

# Testing
<!-- Describe any testing that was performed to validate the solution. -->

<!-- REQUIRED -->
<!-- Describe how changes were tested and provide *reproducible* and *self-contained* code blocks -->
<!-- That is, reviewers ought to be able to run the test code as-is in a new worksheet  -->
<!-- If changes cannot be tested (e.g., some account-level changes), briefly explain why this is the case -->

<!-- OPTIONAL -->
<!-- Link to automated tests -->
<!-- Provide additional information that could give reviewers further confidence in your solution --> 

[SNOW-336]: https://sagebionetworks.jira.com/browse/SNOW-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ