### PR TITLE
[POC] Manage Snowflake infrastructure via Terraform

### DIFF
--- a/terraform/account/integrations.tf
+++ b/terraform/account/integrations.tf
@@ -1,0 +1,79 @@
+# ── Integrations ───────────────────────────────────────────────────────────────
+# Covers SAML2, OAuth (Tableau), and S3 storage integrations.
+# All require ACCOUNTADMIN (the default provider in this root module).
+# Mirrors: admin/integrations.sql
+
+# ── Google SSO (SAML2) ────────────────────────────────────────────────────────
+resource "snowflake_saml2_integration" "google_sso" {
+  name                                = "GOOGLE_SSO"
+  saml2_provider                      = "CUSTOM"
+  saml2_issuer                        = var.saml2_issuer
+  saml2_sso_url                       = var.saml2_sso_url
+  saml2_x509_cert                     = var.saml2_x509_cert
+  saml2_snowflake_acs_url             = "https://mqzfhld-vp00034.snowflakecomputing.com/fed/login"
+  saml2_snowflake_issuer_url          = "https://mqzfhld-vp00034.snowflakecomputing.com"
+  enabled                             = true
+  saml2_sp_initiated_login_page_label = "GOOGLE_SSO"
+  saml2_enable_sp_initiated           = true
+  saml2_sign_request                  = true
+}
+
+# ── Tableau OAuth ─────────────────────────────────────────────────────────────
+resource "snowflake_oauth_integration_for_partner_applications" "tableau_server" {
+  name                         = "TS_OAUTH_INT2"
+  oauth_client                 = "TABLEAU_SERVER"
+  enabled                      = true
+  oauth_refresh_token_validity = 86400
+}
+
+resource "snowflake_oauth_integration_for_partner_applications" "tableau_desktop" {
+  name                         = "TD_OAUTH_INT2"
+  oauth_client                 = "TABLEAU_DESKTOP"
+  enabled                      = true
+  oauth_refresh_token_validity = 36000
+}
+
+# ── S3 storage integrations ───────────────────────────────────────────────────
+# Synapse RDS snapshot pipeline (SNOW-392) — dev + prod
+resource "snowflake_storage_integration" "synapse_snapshots_dev" {
+  name                      = "SYNAPSE_SNAPSHOTS_DEV"
+  type                      = "EXTERNAL_STAGE"
+  enabled                   = true
+  storage_provider          = "S3"
+  storage_aws_role_arn      = "arn:aws:iam::766808016710:role/snowflake-role-synapse-snowflake-rds-snapshots-dev"
+  storage_allowed_locations = ["s3://synapse-snowflake-rds-snapshots-dev"]
+}
+
+resource "snowflake_storage_integration" "synapse_snapshots_prod" {
+  name                      = "SYNAPSE_SNAPSHOTS_PROD"
+  type                      = "EXTERNAL_STAGE"
+  enabled                   = true
+  storage_provider          = "S3"
+  storage_aws_role_arn      = "arn:aws:iam::766808016710:role/snowflake-role-synapse-snowflake-rds-snapshots-prod"
+  storage_allowed_locations = ["s3://synapse-snowflake-rds-snapshots-prod"]
+}
+
+# Synapse event/file-handle data (SNOW-14) — dev + prod
+resource "snowflake_storage_integration" "synapse_prod_warehouse_s3" {
+  name    = "SYNAPSE_PROD_WAREHOUSE_S3"
+  type    = "EXTERNAL_STAGE"
+  enabled = true
+  storage_provider     = "S3"
+  storage_aws_role_arn = "arn:aws:iam::325565585839:role/snowflake-access-SnowflakeServiceRole-2JSCDRkX8TcW"
+  storage_allowed_locations = [
+    "s3://prod.datawarehouse.sagebase.org",
+    "s3://prod.filehandles.sagebase.org",
+  ]
+}
+
+resource "snowflake_storage_integration" "synapse_dev_warehouse_s3" {
+  name    = "SYNAPSE_DEV_WAREHOUSE_S3"
+  type    = "EXTERNAL_STAGE"
+  enabled = true
+  storage_provider     = "S3"
+  storage_aws_role_arn = "arn:aws:iam::449435941126:role/snowflake-access-SnowflakeServiceRole-BKQMHdbc4uU4"
+  storage_allowed_locations = [
+    "s3://dev.datawarehouse.sagebase.org",
+    "s3://dev.filehandles.sagebase.org",
+  ]
+}

--- a/terraform/account/main.tf
+++ b/terraform/account/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    snowflake = {
+      source  = "Snowflake-Labs/snowflake"
+      version = "~> 1.0"
+    }
+  }
+
+  cloud {
+    organization = "sage-bionetworks"
+    workspaces {
+      name = "snowflake-account"
+    }
+  }
+}
+
+# Default provider operates as ACCOUNTADMIN — required for integrations and policies.
+provider "snowflake" {
+  organization_name      = var.snowflake_organization_name
+  account_name           = var.snowflake_account_name
+  user                   = var.snowflake_user
+  authenticator          = "SNOWFLAKE_JWT"
+  private_key            = var.snowflake_private_key
+  private_key_passphrase = var.snowflake_private_key_passphrase
+  role                   = "ACCOUNTADMIN"
+}

--- a/terraform/account/policies.tf
+++ b/terraform/account/policies.tf
@@ -1,0 +1,75 @@
+# ── Account security policies ──────────────────────────────────────────────────
+# Mirrors: admin/policies/V1.10.0 + V1.10.1 + V1.17.0
+# ACCOUNTADMIN is the default provider in this root module.
+#
+# NOTE on applying policies to accounts/users:
+# Snowflake requires UNSET before SET at the account level (no FORCE in all cases).
+# The attachment resources below are commented out for objects that need manual
+# attention on first apply.  Uncomment once the existing policy has been unset.
+
+# ── Password policy ───────────────────────────────────────────────────────────
+resource "snowflake_password_policy" "default" {
+  database              = "POLICY_DB"
+  schema                = "PUBLIC"
+  name                  = "PASSWORD_POLICY"
+  password_min_length   = 14
+  password_max_age_days = 0  # Never expire — SSO users have no password anyway
+}
+
+# ── Session policies ──────────────────────────────────────────────────────────
+resource "snowflake_session_policy" "admin_timeout" {
+  name                         = "ADMIN_TIMEOUT_POLICY"
+  session_idle_timeout_mins    = 15
+  session_ui_idle_timeout_mins = 15
+  comment                      = "Short idle timeout for admin-role sessions"
+}
+
+# ── Authentication policies ───────────────────────────────────────────────────
+# Three tiers: service accounts (password only), admins (SAML + password), users (SAML only)
+
+resource "snowflake_authentication_policy" "service_account" {
+  name                   = "SERVICE_ACCOUNT_AUTHENTICATION_POLICY"
+  authentication_methods = ["PASSWORD"]
+  comment                = "Service accounts use key-pair / password; no SAML"
+}
+
+resource "snowflake_authentication_policy" "admin" {
+  name                   = "ADMIN_AUTHENTICATION_POLICY"
+  authentication_methods = ["SAML", "PASSWORD"]
+  security_integrations  = ["GOOGLE_SSO", "JUMPCLOUD"]
+  comment                = "Human admins: SSO preferred, password allowed for break-glass"
+}
+
+resource "snowflake_authentication_policy" "user" {
+  name                   = "USER_AUTHENTICATION_POLICY"
+  authentication_methods = ["SAML"]
+  security_integrations  = ["GOOGLE_SSO"]
+  comment                = "Standard users: SAML (Google SSO) only"
+}
+
+# ── Policy attachments ────────────────────────────────────────────────────────
+# Attaching policies to specific admin users; all others fall through to the
+# account-level policy.  Attach resources only after verifying no existing
+# policy is set on the target user (Snowflake rejects SET without prior UNSET).
+
+resource "snowflake_user_authentication_policy_attachment" "admin_users" {
+  for_each = toset([
+    "thomas.yu@sagebase.org",
+    "khai.do@sagebase.org",
+    "x.schildwachter@sagebase.org",
+    "phil.snyder@sagebase.org",
+  ])
+  user_name                  = each.value
+  authentication_policy_name = snowflake_authentication_policy.admin.fully_qualified_name
+}
+
+resource "snowflake_user_authentication_policy_attachment" "service_accounts" {
+  for_each = toset([
+    "DPE_SERVICE",
+    "DEVELOPER_SERVICE",
+    "ADMIN_SERVICE",
+    "GENIE_SERVICE",
+  ])
+  user_name                  = each.value
+  authentication_policy_name = snowflake_authentication_policy.service_account.fully_qualified_name
+}

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -1,0 +1,50 @@
+# ── Snowflake connection ──────────────────────────────────────────────────────
+
+variable "snowflake_organization_name" {
+  description = "Snowflake organization name — first segment of the account locator (e.g. 'MQZFHLD')"
+  type        = string
+}
+
+variable "snowflake_account_name" {
+  description = "Snowflake account name — second segment of the account locator (e.g. 'VP00034')"
+  type        = string
+}
+
+variable "snowflake_user" {
+  description = "Snowflake user to authenticate as (ADMIN_SERVICE for most operations)"
+  type        = string
+}
+
+variable "snowflake_private_key" {
+  description = "PEM-encoded RSA private key for key-pair authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "snowflake_private_key_passphrase" {
+  description = "Passphrase for the encrypted private key; omit if key is unencrypted"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+# ── SAML2 / Google SSO ────────────────────────────────────────────────────────
+# Sourced from GitHub Secrets / HCP Terraform variable set. Never hardcode.
+
+variable "saml2_issuer" {
+  description = "Google Workspace SAML2 issuer URL"
+  type        = string
+  sensitive   = true
+}
+
+variable "saml2_sso_url" {
+  description = "Google Workspace SAML2 SSO redirect URL"
+  type        = string
+  sensitive   = true
+}
+
+variable "saml2_x509_cert" {
+  description = "Google Workspace SAML2 x509 certificate (PEM body, no header/footer lines)"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/identity/grants.tf
+++ b/terraform/identity/grants.tf
@@ -1,0 +1,253 @@
+# ── Privilege grants ───────────────────────────────────────────────────────────
+# Covers warehouse usage, database/schema privileges, integration grants, and
+# account-level privilege grants (EXECUTE TASK, APPLY MASKING POLICY, etc.).
+# Mirrors: admin/grants.sql
+#
+# Does NOT include:
+#   - Ownership transfers → admin/ownership_grants/ (side-effect: auto-suspends tasks)
+#   - Future grants       → admin/future_grants/    (versioned schemachange migrations)
+
+# ── Account-level privileges ──────────────────────────────────────────────────
+# provider: snowflake.accountadmin
+
+resource "snowflake_grant_privileges_to_account_role" "taskadmin_execute_task" {
+  provider   = snowflake.accountadmin
+  role_name  = "TASKADMIN"
+  privileges = ["EXECUTE TASK", "EXECUTE MANAGED TASK"]
+  on_account = true
+}
+
+resource "snowflake_grant_privileges_to_account_role" "masking_admin_apply_policy" {
+  provider   = snowflake.accountadmin
+  role_name  = "MASKING_ADMIN"
+  privileges = ["APPLY MASKING POLICY"]
+  on_account = true
+}
+
+resource "snowflake_grant_privileges_to_account_role" "data_engineer_create_database" {
+  provider   = snowflake.accountadmin
+  role_name  = "DATA_ENGINEER"
+  privileges = ["CREATE DATABASE"]
+  on_account = true
+}
+
+resource "snowflake_grant_privileges_to_account_role" "sdw_admin_create_database" {
+  provider   = snowflake.accountadmin
+  role_name  = "SYNAPSE_DATA_WAREHOUSE_ADMIN"
+  privileges = ["CREATE DATABASE"]
+  on_account = true
+}
+
+resource "snowflake_grant_privileges_to_account_role" "sdw_dev_admin_create_database" {
+  provider   = snowflake.accountadmin
+  role_name  = "SYNAPSE_DATA_WAREHOUSE_DEV_ADMIN"
+  privileges = ["CREATE DATABASE"]
+  on_account = true
+}
+
+# ── Warehouse usage ───────────────────────────────────────────────────────────
+# provider: snowflake.securityadmin
+
+resource "snowflake_grant_privileges_to_account_role" "warehouse_compute_xsmall" {
+  for_each   = toset(["DATA_ANALYTICS", "GOVERNANCE", "TECH_PRODUCT"])
+  provider   = snowflake.securityadmin
+  role_name  = each.value
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "WAREHOUSE"
+    object_name = "COMPUTE_XSMALL"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "warehouse_tableau_xsmall" {
+  provider   = snowflake.securityadmin
+  role_name  = "GENIE_ADMIN"
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "WAREHOUSE"
+    object_name = "TABLEAU_XSMALL"
+  }
+}
+
+# ── Storage integration grants ────────────────────────────────────────────────
+resource "snowflake_grant_privileges_to_account_role" "integration_synapse_prod_s3" {
+  for_each   = toset(["SYSADMIN", "DATA_ENGINEER"])
+  provider   = snowflake.securityadmin
+  role_name  = each.value
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "INTEGRATION"
+    object_name = "SYNAPSE_PROD_WAREHOUSE_S3"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "integration_synapse_dev_s3" {
+  provider   = snowflake.securityadmin
+  role_name  = "SYSADMIN"
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "INTEGRATION"
+    object_name = "SYNAPSE_DEV_WAREHOUSE_S3"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "integration_snapshots_dev" {
+  for_each   = toset(["DATA_ENGINEER", "SYNAPSE_DATA_WAREHOUSE_DEV_PROXY_ADMIN"])
+  provider   = snowflake.securityadmin
+  role_name  = each.value
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "INTEGRATION"
+    object_name = "SYNAPSE_SNAPSHOTS_DEV"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "integration_snapshots_prod" {
+  for_each   = toset(["DATA_ENGINEER", "SYNAPSE_DATA_WAREHOUSE_PROXY_ADMIN"])
+  provider   = snowflake.securityadmin
+  role_name  = each.value
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "INTEGRATION"
+    object_name = "SYNAPSE_SNAPSHOTS_PROD"
+  }
+}
+
+# ── Database-level grants ─────────────────────────────────────────────────────
+
+resource "snowflake_grant_privileges_to_account_role" "sage_db_public" {
+  provider   = snowflake.securityadmin
+  role_name  = "PUBLIC"
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "DATABASE"
+    object_name = "SAGE"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "sage_db_data_engineer" {
+  provider   = snowflake.securityadmin
+  role_name  = "DATA_ENGINEER"
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "DATABASE"
+    object_name = "SAGE"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "sage_db_data_analytics" {
+  provider   = snowflake.securityadmin
+  role_name  = "DATA_ANALYTICS"
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "DATABASE"
+    object_name = "SAGE"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "ip_info_data_engineer" {
+  provider   = snowflake.securityadmin
+  role_name  = "DATA_ENGINEER"
+  privileges = ["IMPORTED PRIVILEGES"]
+  on_account_object {
+    object_type = "DATABASE"
+    object_name = "IP_INFO"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "ip_info_governance" {
+  provider   = snowflake.securityadmin
+  role_name  = "GOVERNANCE"
+  privileges = ["IMPORTED PRIVILEGES"]
+  on_account_object {
+    object_type = "DATABASE"
+    object_name = "IP_INFO"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "ip_info_data_analytics" {
+  provider   = snowflake.securityadmin
+  role_name  = "DATA_ANALYTICS"
+  privileges = ["IMPORTED PRIVILEGES"]
+  on_account_object {
+    object_type = "DATABASE"
+    object_name = "IP_INFO"
+  }
+}
+
+# ── Schema-level grants ───────────────────────────────────────────────────────
+
+resource "snowflake_grant_privileges_to_account_role" "sage_ad_schema_ad_role" {
+  provider   = snowflake.securityadmin
+  role_name  = "AD"
+  privileges = ["ALL PRIVILEGES"]
+  on_schema {
+    schema_name = "SAGE.AD"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "sage_ad_usage_ad_role" {
+  provider   = snowflake.securityadmin
+  role_name  = "AD"
+  privileges = ["USAGE"]
+  on_account_object {
+    object_type = "DATABASE"
+    object_name = "SAGE"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "sage_nf_schema" {
+  provider   = snowflake.securityadmin
+  role_name  = "NF_ADMIN"
+  privileges = ["ALL PRIVILEGES"]
+  on_schema {
+    schema_name = "SAGE.NF"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "sage_scidata_schema" {
+  provider   = snowflake.securityadmin
+  role_name  = "SCIDATA_ADMIN"
+  privileges = ["ALL PRIVILEGES"]
+  on_schema {
+    schema_name = "SAGE.SCIDATA"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "masking_policy_create_on_synapse" {
+  provider   = snowflake.securityadmin
+  role_name  = "MASKING_ADMIN"
+  privileges = ["CREATE MASKING POLICY"]
+  on_schema {
+    schema_name = "SYNAPSE_DATA_WAREHOUSE.SYNAPSE"
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "governance_procedures" {
+  provider   = snowflake.securityadmin
+  role_name  = "GOVERNANCE"
+  privileges = ["USAGE"]
+  on_schema_object {
+    all {
+      object_type_plural = "PROCEDURES"
+      in_database        = "SYNAPSE_DATA_WAREHOUSE"
+    }
+  }
+}
+
+# ── Database role → account role grants ──────────────────────────────────────
+# Grants SDW database roles to the matching account roles so the RBAC hierarchy
+# described in admin/CLAUDE.md flows through correctly.
+# provider: snowflake.securityadmin
+
+resource "snowflake_grant_database_role" "synapse_all_analyst_to_data_analytics" {
+  provider                 = snowflake.securityadmin
+  database_role_name       = "SYNAPSE_DATA_WAREHOUSE.SYNAPSE_ALL_ANALYST"
+  parent_account_role_name = "DATA_ANALYTICS"
+}
+
+resource "snowflake_grant_database_role" "schemachange_all_analyst_to_data_analytics" {
+  provider                 = snowflake.securityadmin
+  database_role_name       = "SYNAPSE_DATA_WAREHOUSE.SCHEMACHANGE_ALL_ANALYST"
+  parent_account_role_name = "DATA_ANALYTICS"
+}

--- a/terraform/identity/main.tf
+++ b/terraform/identity/main.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    snowflake = {
+      source  = "Snowflake-Labs/snowflake"
+      version = "~> 1.0"
+    }
+  }
+
+  cloud {
+    organization = "sage-bionetworks"
+    workspaces {
+      name = "snowflake-identity"
+    }
+  }
+}
+
+# Default provider as USERADMIN — creates users and roles.
+provider "snowflake" {
+  organization_name      = var.snowflake_organization_name
+  account_name           = var.snowflake_account_name
+  user                   = var.snowflake_user
+  authenticator          = "SNOWFLAKE_JWT"
+  private_key            = var.snowflake_private_key
+  private_key_passphrase = var.snowflake_private_key_passphrase
+  role                   = "USERADMIN"
+}
+
+# SECURITYADMIN — assigns roles to users/roles (GRANT ROLE requires SECURITYADMIN).
+provider "snowflake" {
+  alias                  = "securityadmin"
+  organization_name      = var.snowflake_organization_name
+  account_name           = var.snowflake_account_name
+  user                   = var.snowflake_user
+  authenticator          = "SNOWFLAKE_JWT"
+  private_key            = var.snowflake_private_key
+  private_key_passphrase = var.snowflake_private_key_passphrase
+  role                   = "SECURITYADMIN"
+}
+
+# ACCOUNTADMIN — account-level privilege grants (EXECUTE TASK, APPLY MASKING POLICY, etc.)
+provider "snowflake" {
+  alias                  = "accountadmin"
+  organization_name      = var.snowflake_organization_name
+  account_name           = var.snowflake_account_name
+  user                   = var.snowflake_user
+  authenticator          = "SNOWFLAKE_JWT"
+  private_key            = var.snowflake_private_key
+  private_key_passphrase = var.snowflake_private_key_passphrase
+  role                   = "ACCOUNTADMIN"
+}

--- a/terraform/identity/role_grants.tf
+++ b/terraform/identity/role_grants.tf
@@ -1,0 +1,326 @@
+# ── Role grants ────────────────────────────────────────────────────────────────
+# Two kinds live here:
+#   1. Role → Role  (hierarchy, e.g. GENIE_ADMIN → SYSADMIN)
+#   2. Role → User  (assignment, e.g. DATA_ENGINEER → thomas.yu@sagebase.org)
+#
+# provider: snowflake.securityadmin — SECURITYADMIN is required for all GRANT ROLE.
+# Mirrors: admin/grants.sql role-assignment sections.
+
+# ── Role hierarchy (role → parent role) ───────────────────────────────────────
+
+locals {
+  role_to_role = {
+    # Domain roles rolled up into SYSADMIN so admins can switch to them directly
+    "GENIE_ADMIN->SYSADMIN"   = { role = "GENIE_ADMIN",   parent = "SYSADMIN" }
+    "AD->SYSADMIN"            = { role = "AD",            parent = "SYSADMIN" }
+    "NF_ADMIN->SYSADMIN"      = { role = "NF_ADMIN",      parent = "SYSADMIN" }
+    "SCIDATA_ADMIN->SYSADMIN" = { role = "SCIDATA_ADMIN", parent = "SYSADMIN" }
+    "FAIR->SYSADMIN"          = { role = "FAIR",          parent = "SYSADMIN" }
+    "DPE_OPS->SYSADMIN"       = { role = "DPE_OPS",       parent = "SYSADMIN" }
+    "GOVERNANCE->SYSADMIN"    = { role = "GOVERNANCE",    parent = "SYSADMIN" }
+    "SAGE_LEADERS->SYSADMIN"  = { role = "SAGE_LEADERS",  parent = "SYSADMIN" }
+    "DATA_ENGINEER->SYSADMIN" = { role = "DATA_ENGINEER", parent = "SYSADMIN" }
+    "MASKING_ADMIN->SYSADMIN" = { role = "MASKING_ADMIN", parent = "SYSADMIN" }
+    "TASKADMIN->DATA_ENGINEER" = { role = "TASKADMIN",    parent = "DATA_ENGINEER" }
+
+    # SDW domain roles
+    "SDW_ADMIN->SYSADMIN"              = { role = "SYNAPSE_DATA_WAREHOUSE_ADMIN",         parent = "SYSADMIN" }
+    "SDW_DEV_ADMIN->SYSADMIN"          = { role = "SYNAPSE_DATA_WAREHOUSE_DEV_ADMIN",     parent = "SYSADMIN" }
+    "SDW_ANALYST->SDW_ADMIN"           = { role = "SYNAPSE_DATA_WAREHOUSE_ANALYST",       parent = "SYNAPSE_DATA_WAREHOUSE_ADMIN" }
+    "SDW_DEV_ANALYST->SDW_DEV_ADMIN"   = { role = "SYNAPSE_DATA_WAREHOUSE_DEV_ANALYST",   parent = "SYNAPSE_DATA_WAREHOUSE_DEV_ADMIN" }
+    "SDW_ANALYST->AD"                  = { role = "SYNAPSE_DATA_WAREHOUSE_ANALYST",       parent = "AD" }
+
+    # DATA_ANALYTICS is inherited by several leadership/domain roles
+    "DA->SAGE_LEADERS"  = { role = "DATA_ANALYTICS", parent = "SAGE_LEADERS" }
+    "DA->SCIDATA_ADMIN" = { role = "DATA_ANALYTICS", parent = "SCIDATA_ADMIN" }
+    "DA->NF_ADMIN"      = { role = "DATA_ANALYTICS", parent = "NF_ADMIN" }
+    "DA->GENIE_ADMIN"   = { role = "DATA_ANALYTICS", parent = "GENIE_ADMIN" }
+    "DA->GOVERNANCE"    = { role = "DATA_ANALYTICS", parent = "GOVERNANCE" }
+  }
+}
+
+resource "snowflake_grant_account_role" "role_to_role" {
+  for_each         = local.role_to_role
+  provider         = snowflake.securityadmin
+  role_name        = each.value.role
+  parent_role_name = each.value.parent
+}
+
+# ── Role → User assignments ────────────────────────────────────────────────────
+
+locals {
+  accountadmin_users = toset([
+    "x.schildwachter@sagebase.org",
+    "khai.do@sagebase.org",
+    "phil.snyder@sagebase.org",
+  ])
+
+  sysadmin_users = toset([
+    "x.schildwachter@sagebase.org",
+    "phil.snyder@sagebase.org",
+    "DPE_SERVICE",
+  ])
+
+  data_engineer_users = toset([
+    "phil.snyder@sagebase.org",
+    "rixing.xu@sagebase.org",
+    "thomas.yu@sagebase.org",
+    "brad.macdonald@sagebase.org",
+    "bryan.fauble@sagebase.org",
+    "nick.grosenbacher@sagebase.org",
+    "jenny.medina@sagebase.org",
+    "DPE_SERVICE",
+  ])
+
+  genie_admin_users = toset([
+    "alexander.paynter@sagebase.org",
+    "xindi.guo@sagebase.org",
+    "chelsea.nayan@sagebase.org",
+    "rixing.xu@sagebase.org",
+    "adam.taylor@sagebase.org",
+    "GENIE_SERVICE",
+  ])
+
+  ad_users = toset([
+    "samia.ahmed@sagebase.org",
+  ])
+
+  nf_admin_users = toset([
+    "anh.nguyet.vu@sagebase.org",
+    "thomas.yu@sagebase.org",
+  ])
+
+  scidata_admin_users = toset([
+    "susheel.varma@sagebase.org",
+    "thomas.yu@sagebase.org",
+  ])
+
+  masking_admin_users = toset([
+    "thomas.yu@sagebase.org",
+  ])
+
+  dpe_ops_users = toset([
+    "thomas.yu@sagebase.org",
+    "sophia.jobe@sagebase.org",
+  ])
+
+  governance_users = toset([
+    "christine.suver@sagebase.org",
+    "kimberly.corrigan@sagebase.org",
+    "ann.novakowski@sagebase.org",
+    "anthony.pena@sagebase.org",
+    "samia.ahmed@sagebase.org",
+    "jonathan.liaw-gray@sagebase.org",
+    "samuel.cason@sagebase.org",
+    "amelia.weixler@sagebase.org",
+  ])
+
+  fair_users = toset([
+    "anthony.williams@sagebase.org",
+    "loren.wolfe@sagebase.org",
+    "lingling.peng@sagebase.org",
+    "gianna.jordan@sagebase.org",
+    "mieko.hashimoto@sagebase.org",
+    "andrew.lamb@sagebase.org",
+    "milen.nikolov@sagebase.org",
+    "amy.heiser@sagebase.org",
+  ])
+
+  sage_leaders_users = toset([
+    "luca.foschini@sagebase.org",
+    "alberto.pepe@sagebase.org",
+    "susheel.varma@sagebase.org",
+    "christine.suver@sagebase.org",
+    "mackenzie.wildman@sagebase.org",
+    "amy.heiser@sagebase.org",
+    "brandon.morgan@sagebase.org",
+    "thomas.yu@sagebase.org",
+    "milen.nikolov@sagebase.org",
+    "andrea.varsavsky@sagebase.org",
+    "kim.baggett@sagebase.org",
+  ])
+}
+
+resource "snowflake_grant_account_role" "accountadmin_to_users" {
+  for_each  = local.accountadmin_users
+  provider  = snowflake.securityadmin
+  role_name = "ACCOUNTADMIN"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "sysadmin_to_users" {
+  for_each  = local.sysadmin_users
+  provider  = snowflake.securityadmin
+  role_name = "SYSADMIN"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "data_engineer_to_users" {
+  for_each  = local.data_engineer_users
+  provider  = snowflake.securityadmin
+  role_name = "DATA_ENGINEER"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "genie_admin_to_users" {
+  for_each  = local.genie_admin_users
+  provider  = snowflake.securityadmin
+  role_name = "GENIE_ADMIN"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "ad_to_users" {
+  for_each  = local.ad_users
+  provider  = snowflake.securityadmin
+  role_name = "AD"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "nf_admin_to_users" {
+  for_each  = local.nf_admin_users
+  provider  = snowflake.securityadmin
+  role_name = "NF_ADMIN"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "scidata_admin_to_users" {
+  for_each  = local.scidata_admin_users
+  provider  = snowflake.securityadmin
+  role_name = "SCIDATA_ADMIN"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "masking_admin_to_users" {
+  for_each  = local.masking_admin_users
+  provider  = snowflake.securityadmin
+  role_name = "MASKING_ADMIN"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "dpe_ops_to_users" {
+  for_each  = local.dpe_ops_users
+  provider  = snowflake.securityadmin
+  role_name = "DPE_OPS"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "governance_to_users" {
+  for_each  = local.governance_users
+  provider  = snowflake.securityadmin
+  role_name = "GOVERNANCE"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "fair_to_users" {
+  for_each  = local.fair_users
+  provider  = snowflake.securityadmin
+  role_name = "FAIR"
+  user_name = each.value
+}
+
+resource "snowflake_grant_account_role" "sage_leaders_to_users" {
+  for_each  = local.sage_leaders_users
+  provider  = snowflake.securityadmin
+  role_name = "SAGE_LEADERS"
+  user_name = each.value
+}
+
+# DATA_ANALYTICS is granted to a large set of users (all analysts + team members)
+resource "snowflake_grant_account_role" "data_analytics_to_users" {
+  for_each = toset([
+    "diep.thach@sagebase.org",
+    "rixing.xu@sagebase.org",
+    "thomas.yu@sagebase.org",
+    "anh.nguyet.vu@sagebase.org",
+    "luca.foschini@sagebase.org",
+    "xindi.guo@sagebase.org",
+    "phil.snyder@sagebase.org",
+    "chelsea.nayan@sagebase.org",
+    "alexander.paynter@sagebase.org",
+    "x.schildwachter@sagebase.org",
+    "kevin.boske@sagebase.org",
+    "brad.macdonald@sagebase.org",
+    "robert.allaway@sagebase.org",
+    "victor.baham@sagebase.org",
+    "elias.chaibub.neto@sagebase.org",
+    "bryan.fauble@sagebase.org",
+    "john.hill@sagebase.org",
+    "bruce.hoff@sagebase.org",
+    "marco.marasca@sagebase.org",
+    "sandhra.sokhal@sagebase.org",
+    "adam.hindman@sagebase.org",
+    "jessica.malenfant@sagebase.org",
+    "ann.novakowski@sagebase.org",
+    "christine.suver@sagebase.org",
+    "adam.taylor@sagebase.org",
+    "sophia.jobe@sagebase.org",
+    "thomas.schaffter@sagebase.org",
+    "solly.sieberts@sagebase.org",
+    "dan.lu@sagebase.org",
+    "jessica.britton@sagebase.org",
+    "zoe.leanza@sagebase.org",
+    "jay.hodgson@sagebase.org",
+    "milan.vu@sagebase.org",
+    "ashley.clayton@sagebase.org",
+    "verena.chung@sagebase.org",
+    "jineta.banerjee@sagebase.org",
+    "jenny.medina@sagebase.org",
+    "sonia.carlson@sagebase.org",
+    "anthony.williams@sagebase.org",
+    "loren.wolfe@sagebase.org",
+    "lingling.peng@sagebase.org",
+    "gianna.jordan@sagebase.org",
+    "mieko.hashimoto@sagebase.org",
+    "andrew.lamb@sagebase.org",
+    "milen.nikolov@sagebase.org",
+    "amy.heiser@sagebase.org",
+    "rchai@sagebase.org",
+    "maria.diaz@sagebase.org",
+    "gaia.andreoletti@sagebase.org",
+    "susheel.varma@sagebase.org",
+    "amber.nelson@sagebase.org",
+    "tiara.adams@sagebase.org",
+    "william.poehlman@sagebase.org",
+    "alberto.pepe@sagebase.org",
+    "jessica.vera@sagebase.org",
+    "kimberly.corrigan@sagebase.org",
+    "mackenzie.wildman@sagebase.org",
+    "aditi.gopalan@sagebase.org",
+    "angie.bowen@sagebase.org",
+    "aditya.nath@sagebase.org",
+    "james.moon@sagebase.org",
+    "orion.banks@sagebase.org",
+    "jo.scanlan@sagebase.org",
+    "trisha.zintel@sagebase.org",
+    "anthony.pena@sagebase.org",
+    "bishoy.kamel@sagebase.org",
+    "andrea.varsavsky@sagebase.org",
+    "serghei.mangul@sagebase.org",
+    "jaclyn.beck@sagebase.org",
+    "ziwei.pan@sagebase.org",
+    "karina.leal@sagebase.org",
+    "ann.campton@sagebase.org",
+    "savitha.sangameswaran@sagebase.org",
+    "vanessa.barone@sagebase.org",
+    "jonathan.liaw-gray@sagebase.org",
+    "laura.heath@sagebase.org",
+    "melissa.klein@sagebase.org",
+    "sarah.mansfield@sagebase.org",
+    "andree-anne.berthiaume@sagebase.org",
+    "dottie.young@sagebase.org",
+    "jordan.driscoll@sagebase.org",
+    "ram.ayyala@sagebase.org",
+    "beatriz.saldana@sagebase.org",
+    "tera.derita@sagebase.org",
+    "belinda.garana@sagebase.org",
+    "emma.costa@sagebase.org",
+    "julia.gray@sagebase.org",
+    "luisa.chekrygin@sagebase.org",
+    "laurielle.roberson@sagebase.org",
+    "samuel.cason@sagebase.org",
+    "amelia.weixler@sagebase.org",
+  ])
+  provider  = snowflake.securityadmin
+  role_name = "DATA_ANALYTICS"
+  user_name = each.value
+}

--- a/terraform/identity/roles.tf
+++ b/terraform/identity/roles.tf
@@ -1,0 +1,52 @@
+# ── Account roles ──────────────────────────────────────────────────────────────
+# Mirrors: admin/roles.sql
+# Default provider (USERADMIN) creates roles.
+# Role-to-role and role-to-user grants live in role_grants.tf (SECURITYADMIN).
+
+locals {
+  account_roles = {
+    # System-wide
+    MASKING_ADMIN    = "Manages column-level masking policies across all databases"
+    DATA_ENGINEER    = "Synapse data engineering — full access to SDW schemas"
+    DATA_ANALYTICS   = "Broad read access for analysts across all public schemas"
+    TASKADMIN        = "Execute and manage Snowflake tasks (EXECUTE TASK privilege)"
+    DPE_OPS          = "DPE operational role for pipeline administration"
+    SAGE_LEADERS     = "Sage Bionetworks leadership — inherits DATA_ANALYTICS"
+
+    # Domain / project roles
+    GENIE_ADMIN      = "GENIE cancer genomics snowflake administrators"
+    AD               = "Alzheimer's Disease data access (SAGE.AD schema)"
+    FAIR             = "FAIR data team"
+    GOVERNANCE       = "Data governance team"
+    NF_ADMIN         = "NF Rare Disease data admin (SAGE.NF schema)"
+    SCIDATA_ADMIN    = "SciData admin (SAGE.SCIDATA schema)"
+    TECH_PRODUCT     = "Raw RDS snapshot access for product analytics"
+
+    # SYNAPSE_DATA_WAREHOUSE (prod)
+    SYNAPSE_DATA_WAREHOUSE_ADMIN       = "Full admin on SYNAPSE_DATA_WAREHOUSE (prod)"
+    SYNAPSE_DATA_WAREHOUSE_ANALYST     = "Read access on SYNAPSE_DATA_WAREHOUSE (prod)"
+    SYNAPSE_DATA_WAREHOUSE_PROXY_ADMIN = "Owns database roles in SYNAPSE_DATA_WAREHOUSE"
+
+    # SYNAPSE_DATA_WAREHOUSE_DEV
+    SYNAPSE_DATA_WAREHOUSE_DEV_ADMIN       = "Full admin on SYNAPSE_DATA_WAREHOUSE_DEV"
+    SYNAPSE_DATA_WAREHOUSE_DEV_ANALYST     = "Read access on SYNAPSE_DATA_WAREHOUSE_DEV"
+    SYNAPSE_DATA_WAREHOUSE_DEV_PROXY_ADMIN = "Owns database roles in SYNAPSE_DATA_WAREHOUSE_DEV"
+
+    # SAGE database
+    SAGE_ADMIN              = "Admin for the SAGE cross-cutting database"
+    SAGE_CITATIONS_ADMIN    = "Admin for SAGE.CITATIONS schema"
+    SAGE_CITATIONS_ANALYST  = "Read access for SAGE.CITATIONS schema"
+    SAGE_GOVERNANCE_ADMIN   = "Admin for SAGE.GOVERNANCE schema"
+    SAGE_GOVERNANCE_ANALYST = "Read access for SAGE.GOVERNANCE schema"
+
+    # Google Analytics
+    GOOGLE_ANALYTICS_AGGREGATE_ADMIN = "Admin for SAGE.GOOGLE_ANALYTICS_AGGREGATE schema"
+  }
+}
+
+resource "snowflake_account_role" "roles" {
+  for_each = local.account_roles
+  name     = each.key
+  comment  = each.value
+  # Default provider (USERADMIN) is used
+}

--- a/terraform/identity/users.tf
+++ b/terraform/identity/users.tf
@@ -1,0 +1,203 @@
+# ── SSO users ─────────────────────────────────────────────────────────────────
+# All human users authenticate via Google SSO (SAML2); no passwords are set.
+# A single for_each loop keeps the list DRY and avoids one resource block per person.
+# Mirrors: admin/users.sql CREATE USER blocks
+#
+# Default provider (USERADMIN) creates users.
+
+locals {
+  # login_name == name for all SSO users (Google Workspace email = Snowflake login)
+  sso_users = toset([
+    # Platform
+    "diep.thach@sagebase.org",
+    "x.schildwachter@sagebase.org",
+    "kevin.boske@sagebase.org",
+    "john.hill@sagebase.org",
+    "bruce.hoff@sagebase.org",
+    "marco.marasca@sagebase.org",
+    "sandhra.sokhal@sagebase.org",
+    "adam.hindman@sagebase.org",
+    "jay.hodgson@sagebase.org",
+    "nick.grosenbacher@sagebase.org",
+    "khai.do@sagebase.org",
+    "thomas.schaffter@sagebase.org",
+    # Cancer Bio
+    "adam.taylor@sagebase.org",
+    "chelsea.nayan@sagebase.org",
+    "xindi.guo@sagebase.org",
+    "alexander.paynter@sagebase.org",
+    "aditi.gopalan@sagebase.org",
+    "amber.nelson@sagebase.org",
+    "jessica.vera@sagebase.org",
+    # ADTR
+    "victor.baham@sagebase.org",
+    "jessica.malenfant@sagebase.org",
+    "jessica.britton@sagebase.org",
+    "zoe.leanza@sagebase.org",
+    "milan.vu@sagebase.org",
+    "william.poehlman@sagebase.org",
+    "jo.scanlan@sagebase.org",
+    "trisha.zintel@sagebase.org",
+    "bishoy.kamel@sagebase.org",
+    "jaclyn.beck@sagebase.org",
+    "karina.leal@sagebase.org",
+    "ann.campton@sagebase.org",
+    "melissa.klein@sagebase.org",
+    "beatriz.saldana@sagebase.org",
+    "andree-anne.berthiaume@sagebase.org",
+    "jordan.driscoll@sagebase.org",
+    "laura.heath@sagebase.org",
+    "tiara.adams@sagebase.org",
+    "emma.costa@sagebase.org",
+    "julia.gray@sagebase.org",
+    # SciData Misc
+    "ashley.clayton@sagebase.org",
+    "vanessa.barone@sagebase.org",
+    "savitha.sangameswaran@sagebase.org",
+    "ram.ayyala@sagebase.org",
+    "angie.bowen@sagebase.org",
+    "tera.derita@sagebase.org",
+    # NF Rare Disease
+    "anh.nguyet.vu@sagebase.org",
+    "robert.allaway@sagebase.org",
+    "james.moon@sagebase.org",
+    "belinda.garana@sagebase.org",
+    # Advanced Data Analytics
+    "jineta.banerjee@sagebase.org",
+    "orion.banks@sagebase.org",
+    "ziwei.pan@sagebase.org",
+    "aditya.nath@sagebase.org",
+    # Digital Health
+    "solly.sieberts@sagebase.org",
+    "elias.chaibub.neto@sagebase.org",
+    "sonia.carlson@sagebase.org",
+    # Governance
+    "kimberly.corrigan@sagebase.org",
+    "anthony.pena@sagebase.org",
+    "jonathan.liaw-gray@sagebase.org",
+    "samuel.cason@sagebase.org",
+    "amelia.weixler@sagebase.org",
+    # CNB
+    "verena.chung@sagebase.org",
+    "rchai@sagebase.org",
+    "maria.diaz@sagebase.org",
+    "gaia.andreoletti@sagebase.org",
+    "serghei.mangul@sagebase.org",
+    # Tech
+    "anthony.williams@sagebase.org",
+    "loren.wolfe@sagebase.org",
+    "mieko.hashimoto@sagebase.org",
+    "milen.nikolov@sagebase.org",
+    "amy.heiser@sagebase.org",
+    "christina.parry@sagebase.org",
+    "ann.novakowski@sagebase.org",
+    "samia.ahmed@sagebase.org",
+    "shaun.kalweit@sagebase.org",
+    # DPE
+    "bryan.fauble@sagebase.org",
+    "rixing.xu@sagebase.org",
+    "thomas.yu@sagebase.org",
+    "jenny.medina@sagebase.org",
+    "phil.snyder@sagebase.org",
+    "sophia.jobe@sagebase.org",
+    "dan.lu@sagebase.org",
+    "lingling.peng@sagebase.org",
+    "gianna.jordan@sagebase.org",
+    "andrew.lamb@sagebase.org",
+    # Leadership
+    "luca.foschini@sagebase.org",
+    "alberto.pepe@sagebase.org",
+    "susheel.varma@sagebase.org",
+    "christine.suver@sagebase.org",
+    "mackenzie.wildman@sagebase.org",
+    "andrea.varsavsky@sagebase.org",
+    "dottie.young@sagebase.org",
+    # Finance
+    "brandon.morgan@sagebase.org",
+    "barry.webb@sagebase.org",
+    "sarah.mansfield@sagebase.org",
+    "ranell.nystrom@sagebase.org",
+    # Sponsored Research
+    "luisa.chekrygin@sagebase.org",
+    "laurielle.roberson@sagebase.org",
+  ])
+
+  # Users that are currently disabled (departed or inactive).
+  # Terraform manages the disabled state; the user resource still exists so grants
+  # referencing it don't error, but login is blocked.
+  disabled_sso_users = toset([
+    "abby.vanderlinden@sagebase.org",
+    "anna.greenwood@sagebase.org",
+    "arti.singh@sagebase.org",
+    "brad.macdonald@sagebase.org",
+    "christina.conrad@sagebase.org",
+    "drew.duglan@sagebase.org",
+    "hayley.sanchez@sagebase.org",
+    "james.eddy@sagebase.org",
+    "kim.baggett@sagebase.org",
+    "lakaija.johnson@sagebase.org",
+    "lisa.pasquale@sagebase.org",
+    "natosha.edmonds@sagebase.org",
+    "nicholas.lee@sagebase.org",
+    "pranav.anbarasu@sagebase.org",
+    "richard.yaxley@sagebase.org",
+    "sarah.chan@sagebase.org",
+    "meghasyam@sagebase.org",
+  ])
+}
+
+resource "snowflake_user" "sso" {
+  for_each   = local.sso_users
+  name       = each.value
+  login_name = each.value
+  # No password — authentication is exclusively via Google SSO (SAML2).
+  # DEFAULT_SECONDARY_ROLES is kept empty per account policy (admin/users.sql).
+  default_secondary_roles_option = "NONE"
+}
+
+resource "snowflake_user" "sso_disabled" {
+  for_each   = local.disabled_sso_users
+  name       = each.value
+  login_name = each.value
+  disabled   = true
+  default_secondary_roles_option = "NONE"
+}
+
+# ── Service accounts ───────────────────────────────────────────────────────────
+# TYPE = SERVICE users have no password and cannot use the UI.
+# Mirrors: admin/users.sql service user blocks
+
+resource "snowflake_service_user" "admin_service" {
+  name    = "ADMIN_SERVICE"
+  comment = "ACCOUNTADMIN-level service account for Terraform and admin automation"
+}
+
+resource "snowflake_service_user" "developer_service" {
+  name    = "DEVELOPER_SERVICE"
+  comment = "DATA_ENGINEER-level service account for developer automation"
+}
+
+resource "snowflake_service_user" "dpe_service" {
+  name    = "DPE_SERVICE"
+  comment = "SYSADMIN + DATA_ENGINEER service account for DPE CI/CD pipelines"
+}
+
+resource "snowflake_service_user" "genie_service" {
+  name    = "GENIE_SERVICE"
+  comment = "Service user for launching Genie workflows in Snowflake"
+}
+
+# ── Legacy service accounts (password-based, disabled) ────────────────────────
+# These predate the TYPE=SERVICE model and are kept disabled.
+
+resource "snowflake_legacy_service_user" "dbt_service" {
+  name     = "DBT_SERVICE"
+  disabled = true
+  comment  = "Deprecated dbt service account — superseded by DPE_SERVICE"
+}
+
+resource "snowflake_legacy_service_user" "ad_service" {
+  name     = "AD_SERVICE"
+  disabled = true
+  comment  = "Deprecated AD service account"
+}

--- a/terraform/identity/variables.tf
+++ b/terraform/identity/variables.tf
@@ -1,0 +1,29 @@
+# ── Snowflake connection ──────────────────────────────────────────────────────
+
+variable "snowflake_organization_name" {
+  description = "Snowflake organization name — first segment of the account locator (e.g. 'MQZFHLD')"
+  type        = string
+}
+
+variable "snowflake_account_name" {
+  description = "Snowflake account name — second segment of the account locator (e.g. 'VP00034')"
+  type        = string
+}
+
+variable "snowflake_user" {
+  description = "Snowflake user to authenticate as (ADMIN_SERVICE for most operations)"
+  type        = string
+}
+
+variable "snowflake_private_key" {
+  description = "PEM-encoded RSA private key for key-pair authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "snowflake_private_key_passphrase" {
+  description = "Passphrase for the encrypted private key; omit if key is unencrypted"
+  type        = string
+  sensitive   = true
+  default     = null
+}

--- a/terraform/infrastructure/databases.tf
+++ b/terraform/infrastructure/databases.tf
@@ -1,0 +1,23 @@
+# ── Databases ──────────────────────────────────────────────────────────────────
+# Mirrors: admin/databases.sql (current state — DROP statements excluded;
+# Terraform should never manage dropped databases)
+# Default provider (SYSADMIN) creates databases.
+#
+# Note: SYNAPSE_DATA_WAREHOUSE_DEV_{branch} clone databases are ephemeral and
+# created by CI, not Terraform. Do not add them here.
+
+locals {
+  databases = toset([
+    "GENIE",
+    "SAGE",
+    "DATA_ANALYTICS",
+    "SYNAPSE_DATA_WAREHOUSE",
+    "SYNAPSE_DATA_WAREHOUSE_DEV",
+    "METADATA",
+  ])
+}
+
+resource "snowflake_database" "databases" {
+  for_each = local.databases
+  name     = each.value
+}

--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    snowflake = {
+      source  = "Snowflake-Labs/snowflake"
+      version = "~> 1.0"
+    }
+  }
+
+  cloud {
+    organization = "sage-bionetworks"
+    workspaces {
+      name = "snowflake-infrastructure"
+    }
+  }
+}
+
+# Default provider as SYSADMIN — creates warehouses and databases.
+provider "snowflake" {
+  organization_name      = var.snowflake_organization_name
+  account_name           = var.snowflake_account_name
+  user                   = var.snowflake_user
+  authenticator          = "SNOWFLAKE_JWT"
+  private_key            = var.snowflake_private_key
+  private_key_passphrase = var.snowflake_private_key_passphrase
+  role                   = "SYSADMIN"
+}

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -1,0 +1,29 @@
+# ── Snowflake connection ──────────────────────────────────────────────────────
+
+variable "snowflake_organization_name" {
+  description = "Snowflake organization name — first segment of the account locator (e.g. 'MQZFHLD')"
+  type        = string
+}
+
+variable "snowflake_account_name" {
+  description = "Snowflake account name — second segment of the account locator (e.g. 'VP00034')"
+  type        = string
+}
+
+variable "snowflake_user" {
+  description = "Snowflake user to authenticate as (ADMIN_SERVICE for most operations)"
+  type        = string
+}
+
+variable "snowflake_private_key" {
+  description = "PEM-encoded RSA private key for key-pair authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "snowflake_private_key_passphrase" {
+  description = "Passphrase for the encrypted private key; omit if key is unencrypted"
+  type        = string
+  sensitive   = true
+  default     = null
+}

--- a/terraform/infrastructure/warehouses.tf
+++ b/terraform/infrastructure/warehouses.tf
@@ -1,0 +1,55 @@
+# ── Warehouses ─────────────────────────────────────────────────────────────────
+# Mirrors: admin/warehouses/V1.0.0 → V1.21.0 (current state after all migrations)
+# Default provider (SYSADMIN) creates warehouses.
+#
+# Naming conventions (from admin/CLAUDE.md):
+#   - XSMALL for most workloads; MEDIUM only for COPY INTO operations
+#   - initially_suspended = true, auto_resume = true on all warehouses
+#   - Tableau warehouse: auto_suspend = 300 (long, to keep query cache warm)
+#   - All others: auto_suspend = 60–90 s
+#   - statement_timeout_in_seconds = 10800 (3 h) to prevent runaway queries
+
+locals {
+  warehouses = {
+    # General-purpose compute (renamed from COMPUTE_ORG in V1.1.0)
+    COMPUTE_XSMALL = {
+      size              = "XSMALL"
+      auto_suspend      = 70
+      max_cluster_count = 50  # Temporarily elevated (V1.21.0); reduce to 10 post-workshop
+    }
+
+    # Heavy ingestion (COPY INTO); kept small cluster count — serial by nature
+    COMPUTE_MEDIUM = {
+      size              = "MEDIUM"
+      auto_suspend      = 70
+      max_cluster_count = 1
+    }
+
+    # RECOVER project workloads
+    RECOVER_XSMALL = {
+      size              = "XSMALL"
+      auto_suspend      = 90
+      max_cluster_count = 1
+    }
+
+    # Tableau (renamed from TABLEAU in V1.1.0); longer suspend for cache warm-up
+    TABLEAU_XSMALL = {
+      size              = "XSMALL"
+      auto_suspend      = 300
+      max_cluster_count = 1
+    }
+  }
+}
+
+resource "snowflake_warehouse" "warehouses" {
+  for_each = local.warehouses
+
+  name           = each.key
+  warehouse_type = "STANDARD"
+  warehouse_size = each.value.size
+  auto_suspend   = each.value.auto_suspend
+  auto_resume    = true
+  initially_suspended          = true
+  max_cluster_count            = each.value.max_cluster_count
+  statement_timeout_in_seconds = 10800
+}

--- a/terraform/modules/synapse_data_warehouse/database_roles.tf
+++ b/terraform/modules/synapse_data_warehouse/database_roles.tf
@@ -1,0 +1,305 @@
+# ── SYNAPSE_DATA_WAREHOUSE database roles ─────────────────────────────────────
+# Mirrors the full database_roles/ V__ migration sequence (current state):
+#   V2.31.0 — SYNAPSE, SYNAPSE_RAW, SCHEMACHANGE admin roles
+#   V2.37.0 — analyst aggregate + object-type-specific read roles
+#   V2.39.0 — ALL_ADMIN proxy role
+#   V2.45.0 — *_ALL_DEVELOPER roles
+#   V2.47.1 — SYNAPSE_AGGREGATE roles
+#   V2.49.1 — SYNAPSE_EVENT roles
+#   V2.64.1 — SYNAPSE_FUNCTION_READ role
+#   V2.66.1 — RDS_LANDING roles
+#   V2.67.1 — RDS_RAW roles
+#   V2.68.0 — RDS_RAW_VIEW_READ role
+#
+# Ownership grants (GRANT OWNERSHIP ON DATABASE ROLE) are handled here;
+# object-level privilege grants (SELECT, USAGE on tables/stages) belong in
+# admin/future_grants/ schemachange migrations — not Terraform.
+# provider: snowflake.sysadmin (CREATE DATABASE ROLE requires object owner or SYSADMIN)
+
+locals {
+  # SYNAPSE schema roles (V2.31.0 + V2.37.0 + V2.45.0 + V2.64.1)
+  synapse_db_roles = [
+    "SYNAPSE_ALL_ADMIN",
+    "SYNAPSE_ALL_ANALYST",
+    "SYNAPSE_ALL_DEVELOPER",
+    "SYNAPSE_TABLE_READ",
+    "SYNAPSE_STAGE_READ",
+    "SYNAPSE_VIEW_READ",
+    "SYNAPSE_TASK_READ",
+    "SYNAPSE_FUNCTION_READ",
+  ]
+
+  # SYNAPSE_RAW schema roles (V2.31.0 + V2.37.0 + V2.45.0)
+  synapse_raw_db_roles = [
+    "SYNAPSE_RAW_ALL_ADMIN",
+    "SYNAPSE_RAW_ALL_ANALYST",
+    "SYNAPSE_RAW_ALL_DEVELOPER",
+    "SYNAPSE_RAW_TABLE_READ",
+    "SYNAPSE_RAW_STAGE_READ",
+    "SYNAPSE_RAW_STREAM_READ",
+    "SYNAPSE_RAW_TASK_READ",
+  ]
+
+  # SCHEMACHANGE schema roles (V2.31.0 + V2.37.0 + V2.45.0)
+  schemachange_db_roles = [
+    "SCHEMACHANGE_ALL_ADMIN",
+    "SCHEMACHANGE_ALL_ANALYST",
+    "SCHEMACHANGE_ALL_DEVELOPER",
+    "SCHEMACHANGE_TABLE_READ",
+  ]
+
+  # SYNAPSE_AGGREGATE schema roles (V2.47.1)
+  synapse_aggregate_db_roles = [
+    "SYNAPSE_AGGREGATE_ALL_ADMIN",
+    "SYNAPSE_AGGREGATE_ALL_ANALYST",
+    "SYNAPSE_AGGREGATE_ALL_DEVELOPER",
+    "SYNAPSE_AGGREGATE_TABLE_READ",
+  ]
+
+  # SYNAPSE_EVENT schema roles (V2.49.1)
+  synapse_event_db_roles = [
+    "SYNAPSE_EVENT_ALL_ADMIN",
+    "SYNAPSE_EVENT_ALL_ANALYST",
+    "SYNAPSE_EVENT_ALL_DEVELOPER",
+    "SYNAPSE_EVENT_TABLE_READ",
+  ]
+
+  # RDS_LANDING schema roles (V2.66.1)
+  rds_landing_db_roles = [
+    "RDS_LANDING_ALL_ADMIN",
+    "RDS_LANDING_ALL_DEVELOPER",
+    "RDS_LANDING_TABLE_READ",
+    "RDS_LANDING_STAGE_READ",
+  ]
+
+  # RDS_RAW schema roles (V2.67.1 + V2.68.0)
+  rds_raw_db_roles = [
+    "RDS_RAW_ALL_ADMIN",
+    "RDS_RAW_ALL_DEVELOPER",
+    "RDS_RAW_TABLE_READ",
+    "RDS_RAW_STAGE_READ",
+    "RDS_RAW_VIEW_READ",
+  ]
+
+  # Proxy admin (V2.39.0)
+  proxy_db_roles = ["ALL_ADMIN"]
+
+  all_db_roles = toset(concat(
+    local.synapse_db_roles,
+    local.synapse_raw_db_roles,
+    local.schemachange_db_roles,
+    local.synapse_aggregate_db_roles,
+    local.synapse_event_db_roles,
+    local.rds_landing_db_roles,
+    local.rds_raw_db_roles,
+    local.proxy_db_roles,
+  ))
+}
+
+resource "snowflake_database_role" "sdw" {
+  for_each = local.all_db_roles
+  provider = snowflake.sysadmin
+  database = var.database_name
+  name     = each.value
+}
+
+# ── Ownership grants (database role → database role / account role) ───────────
+# Mirrors the GRANT OWNERSHIP ON DATABASE ROLE ... statements in V2.31.0–V2.68.0.
+# provider: snowflake.securityadmin
+
+# SYNAPSE namespace (V2.31.0 + V2.37.0 + V2.45.0 + V2.64.1)
+resource "snowflake_grant_database_role" "synapse_all_analyst_owned_by_all_admin" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_ALL_ANALYST"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_ALL_ADMIN"
+}
+
+resource "snowflake_grant_database_role" "synapse_type_reads_owned_by_all_admin" {
+  for_each = toset(["SYNAPSE_TABLE_READ", "SYNAPSE_STAGE_READ", "SYNAPSE_VIEW_READ", "SYNAPSE_TASK_READ", "SYNAPSE_FUNCTION_READ"])
+
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.${each.value}"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_ALL_ADMIN"
+}
+
+resource "snowflake_grant_database_role" "synapse_type_reads_to_all_analyst" {
+  for_each = toset(["SYNAPSE_TABLE_READ", "SYNAPSE_STAGE_READ", "SYNAPSE_VIEW_READ", "SYNAPSE_TASK_READ", "SYNAPSE_FUNCTION_READ"])
+
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.${each.value}"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_ALL_ANALYST"
+}
+
+resource "snowflake_grant_database_role" "synapse_all_developer_inherits_analyst" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_ALL_ANALYST"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_ALL_DEVELOPER"
+}
+
+resource "snowflake_grant_database_role" "synapse_all_developer_inherits_function_read" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_FUNCTION_READ"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_ALL_DEVELOPER"
+}
+
+# SYNAPSE_RAW namespace (V2.31.0 + V2.37.0 + V2.45.0)
+resource "snowflake_grant_database_role" "synapse_raw_analyst_owned_by_all_admin" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_RAW_ALL_ANALYST"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_RAW_ALL_ADMIN"
+}
+
+resource "snowflake_grant_database_role" "synapse_raw_type_reads_owned_by_all_admin" {
+  for_each = toset(["SYNAPSE_RAW_TABLE_READ", "SYNAPSE_RAW_STAGE_READ", "SYNAPSE_RAW_STREAM_READ", "SYNAPSE_RAW_TASK_READ"])
+
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.${each.value}"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_RAW_ALL_ADMIN"
+}
+
+resource "snowflake_grant_database_role" "synapse_raw_type_reads_to_all_analyst" {
+  for_each = toset(["SYNAPSE_RAW_TABLE_READ", "SYNAPSE_RAW_STAGE_READ", "SYNAPSE_RAW_STREAM_READ", "SYNAPSE_RAW_TASK_READ"])
+
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.${each.value}"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_RAW_ALL_ANALYST"
+}
+
+# SYNAPSE_RAW developer inherits type-specific reads directly (not via analyst)
+resource "snowflake_grant_database_role" "synapse_raw_developer_type_reads" {
+  for_each = toset(["SYNAPSE_RAW_TABLE_READ", "SYNAPSE_RAW_STAGE_READ", "SYNAPSE_RAW_STREAM_READ", "SYNAPSE_RAW_TASK_READ"])
+
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.${each.value}"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_RAW_ALL_DEVELOPER"
+}
+
+# SCHEMACHANGE namespace
+resource "snowflake_grant_database_role" "schemachange_analyst_owned_by_all_admin" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SCHEMACHANGE_ALL_ANALYST"
+  parent_database_role_name = "${var.database_name}.SCHEMACHANGE_ALL_ADMIN"
+}
+
+resource "snowflake_grant_database_role" "schemachange_table_read_owned_by_all_admin" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SCHEMACHANGE_TABLE_READ"
+  parent_database_role_name = "${var.database_name}.SCHEMACHANGE_ALL_ADMIN"
+}
+
+resource "snowflake_grant_database_role" "schemachange_table_read_to_analyst" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SCHEMACHANGE_TABLE_READ"
+  parent_database_role_name = "${var.database_name}.SCHEMACHANGE_ALL_ANALYST"
+}
+
+resource "snowflake_grant_database_role" "schemachange_developer_inherits_analyst" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SCHEMACHANGE_ALL_ANALYST"
+  parent_database_role_name = "${var.database_name}.SCHEMACHANGE_ALL_DEVELOPER"
+}
+
+# SYNAPSE_AGGREGATE namespace (V2.47.1)
+resource "snowflake_grant_database_role" "synapse_agg_analyst_owned_by_admin" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_AGGREGATE_ALL_ANALYST"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_AGGREGATE_ALL_ADMIN"
+}
+
+resource "snowflake_grant_database_role" "synapse_agg_table_read_to_analyst" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_AGGREGATE_TABLE_READ"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_AGGREGATE_ALL_ANALYST"
+}
+
+resource "snowflake_grant_database_role" "synapse_agg_developer_inherits_analyst" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_AGGREGATE_ALL_ANALYST"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_AGGREGATE_ALL_DEVELOPER"
+}
+
+# SYNAPSE_EVENT namespace (V2.49.1)
+resource "snowflake_grant_database_role" "synapse_event_analyst_owned_by_admin" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_EVENT_ALL_ANALYST"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_EVENT_ALL_ADMIN"
+}
+
+resource "snowflake_grant_database_role" "synapse_event_table_read_to_analyst" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_EVENT_TABLE_READ"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_EVENT_ALL_ANALYST"
+}
+
+resource "snowflake_grant_database_role" "synapse_event_developer_inherits_analyst" {
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.SYNAPSE_EVENT_ALL_ANALYST"
+  parent_database_role_name = "${var.database_name}.SYNAPSE_EVENT_ALL_DEVELOPER"
+}
+
+# RDS_LANDING namespace (V2.66.1)
+resource "snowflake_grant_database_role" "rds_landing_developer_inherits_type_reads" {
+  for_each = toset(["RDS_LANDING_TABLE_READ", "RDS_LANDING_STAGE_READ"])
+
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.${each.value}"
+  parent_database_role_name = "${var.database_name}.RDS_LANDING_ALL_DEVELOPER"
+}
+
+# RDS_RAW namespace (V2.67.1 + V2.68.0)
+resource "snowflake_grant_database_role" "rds_raw_developer_inherits_type_reads" {
+  for_each = toset(["RDS_RAW_TABLE_READ", "RDS_RAW_STAGE_READ", "RDS_RAW_VIEW_READ"])
+
+  provider                  = snowflake.securityadmin
+  database_role_name        = "${var.database_name}.${each.value}"
+  parent_database_role_name = "${var.database_name}.RDS_RAW_ALL_DEVELOPER"
+}
+
+# ── Database role → account role grants ──────────────────────────────────────
+# Grant top-level database roles to their corresponding account roles.
+# provider: snowflake.securityadmin
+
+# Admin roles to {DATABASE}_ADMIN account role
+resource "snowflake_grant_database_role" "schema_admins_to_db_admin" {
+  for_each = toset(["SYNAPSE_ALL_ADMIN", "SYNAPSE_RAW_ALL_ADMIN", "SCHEMACHANGE_ALL_ADMIN", "ALL_ADMIN"])
+
+  provider                 = snowflake.securityadmin
+  database_role_name       = "${var.database_name}.${each.value}"
+  parent_account_role_name = var.admin_role
+}
+
+# Analyst aggregate roles to {DATABASE}_ANALYST account role
+resource "snowflake_grant_database_role" "schema_analysts_to_db_analyst" {
+  for_each = toset(["SYNAPSE_ALL_ANALYST", "SYNAPSE_RAW_ALL_ANALYST", "SCHEMACHANGE_ALL_ANALYST"])
+
+  provider                 = snowflake.securityadmin
+  database_role_name       = "${var.database_name}.${each.value}"
+  parent_account_role_name = var.analyst_role
+}
+
+# Developer roles to DATA_ENGINEER account role
+resource "snowflake_grant_database_role" "schema_developers_to_data_engineer" {
+  for_each = toset(["SYNAPSE_ALL_DEVELOPER", "SYNAPSE_RAW_ALL_DEVELOPER", "SCHEMACHANGE_ALL_DEVELOPER"])
+
+  provider                 = snowflake.securityadmin
+  database_role_name       = "${var.database_name}.${each.value}"
+  parent_account_role_name = "DATA_ENGINEER"
+}
+
+# SYNAPSE_AGGREGATE and SYNAPSE_EVENT admin roles → proxy admin account role
+resource "snowflake_grant_database_role" "new_schema_admins_to_proxy_admin" {
+  for_each = toset(["SYNAPSE_AGGREGATE_ALL_ADMIN", "SYNAPSE_EVENT_ALL_ADMIN", "RDS_LANDING_ALL_ADMIN", "RDS_RAW_ALL_ADMIN"])
+
+  provider                 = snowflake.securityadmin
+  database_role_name       = "${var.database_name}.${each.value}"
+  parent_account_role_name = var.proxy_admin_role
+}
+
+# RDS developer roles → DATA_ENGINEER
+resource "snowflake_grant_database_role" "rds_developers_to_data_engineer" {
+  for_each = toset(["RDS_LANDING_ALL_DEVELOPER", "RDS_RAW_ALL_DEVELOPER"])
+
+  provider                 = snowflake.securityadmin
+  database_role_name       = "${var.database_name}.${each.value}"
+  parent_account_role_name = "DATA_ENGINEER"
+}

--- a/terraform/modules/synapse_data_warehouse/functions.tf
+++ b/terraform/modules/synapse_data_warehouse/functions.tf
@@ -1,0 +1,24 @@
+# ── SYNAPSE_DATA_WAREHOUSE SQL functions ──────────────────────────────────────
+# Mirrors: synapse_data_warehouse/synapse/functions/V2.64.0__sage_employees_function.sql
+# provider: snowflake.sysadmin
+
+# list_sage_users() — returns Synapse user IDs for current Sage employees.
+# Queries team_id 273957 (the Sage staff Synapse team) via TEAMMEMBER_LATEST.
+resource "snowflake_function_sql" "list_sage_users" {
+  provider = snowflake.sysadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE"
+  name     = "LIST_SAGE_USERS"
+
+  return_type = "TABLE(USER_ID NUMBER)"
+  comment     = "Returns a table with column `user_id` containing the Synapse user IDs of current Sage employees"
+
+  function_definition = <<-SQL
+    SELECT member_id AS user_id
+    FROM ${var.database_name}.synapse.teammember_latest
+    WHERE team_id = 273957
+  SQL
+
+  depends_on = [snowflake_schema.synapse]
+}

--- a/terraform/modules/synapse_data_warehouse/outputs.tf
+++ b/terraform/modules/synapse_data_warehouse/outputs.tf
@@ -1,0 +1,1 @@
+# No outputs required — all objects are referenced by name within Snowflake.

--- a/terraform/modules/synapse_data_warehouse/providers.tf
+++ b/terraform/modules/synapse_data_warehouse/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    snowflake = {
+      source  = "Snowflake-Labs/snowflake"
+      version = "~> 1.0"
+      configuration_aliases = [
+        snowflake.sysadmin,
+        snowflake.securityadmin,
+        snowflake.accountadmin,
+      ]
+    }
+  }
+}

--- a/terraform/modules/synapse_data_warehouse/schemas.tf
+++ b/terraform/modules/synapse_data_warehouse/schemas.tf
@@ -1,0 +1,54 @@
+# ── SYNAPSE_DATA_WAREHOUSE schemas ────────────────────────────────────────────
+# Mirrors: synapse_data_warehouse/synapse_raw/V1.0.0__create_schemas.sql,
+#          synapse_data_warehouse/synapse_aggregate/V2.47.0__create_synapse_aggregate_schema.sql,
+#          synapse_data_warehouse/synapse_event/V2.49.0__create_synapse_event_schema.sql,
+#          synapse_data_warehouse/rds_landing/V2.66.0__create_rds_landing_schema.sql,
+#          synapse_data_warehouse/rds_raw/V2.67.0__create_rds_raw_schema.sql
+#
+# SCHEMACHANGE schema is auto-created by schemachange itself — not managed here.
+# provider: snowflake.sysadmin
+
+# SYNAPSE_RAW — raw S3 Parquet ingest (snapshot tables, stages, streams, tasks)
+resource "snowflake_schema" "synapse_raw" {
+  provider            = snowflake.sysadmin
+  database            = var.database_name
+  name                = "SYNAPSE_RAW"
+  with_managed_access = true
+}
+
+# SYNAPSE — transformed/materialized tables and dynamic tables consumed by dbt
+resource "snowflake_schema" "synapse" {
+  provider            = snowflake.sysadmin
+  database            = var.database_name
+  name                = "SYNAPSE"
+  with_managed_access = true
+}
+
+# SYNAPSE_AGGREGATE — time-window aggregations of user activity (dynamic tables)
+resource "snowflake_schema" "synapse_aggregate" {
+  provider = snowflake.sysadmin
+  database = var.database_name
+  name     = "SYNAPSE_AGGREGATE"
+}
+
+# SYNAPSE_EVENT — derived event tables retaining the most recent snapshot per event
+resource "snowflake_schema" "synapse_event" {
+  provider = snowflake.sysadmin
+  database = var.database_name
+  name     = "SYNAPSE_EVENT"
+  comment  = "Event data is derived from raw data by retaining only the most recent snapshot for each distinct event. The identifier of an event is determined by a subset of columns which uniquely identifies the occurrence or instance of an event."
+}
+
+# RDS_LANDING — external tables + stages for MySQL RDS snapshot ingestion
+resource "snowflake_schema" "rds_landing" {
+  provider = snowflake.sysadmin
+  database = var.database_name
+  name     = "RDS_LANDING"
+}
+
+# RDS_RAW — MySQL RDS snapshot tables (access approvals, requirements, ACLs)
+resource "snowflake_schema" "rds_raw" {
+  provider = snowflake.sysadmin
+  database = var.database_name
+  name     = "RDS_RAW"
+}

--- a/terraform/modules/synapse_data_warehouse/stages.tf
+++ b/terraform/modules/synapse_data_warehouse/stages.tf
@@ -1,0 +1,60 @@
+# ── SYNAPSE_DATA_WAREHOUSE external stages ────────────────────────────────────
+# Mirrors:
+#   synapse_data_warehouse/synapse_raw/V1.1.0__create_stages.sql
+#   synapse_data_warehouse/synapse_raw/V2.16.0__create_file_association_stages.sql
+#   synapse_data_warehouse/rds_landing/V2.69.0__create_stage.sql
+#
+# Stages require an existing storage integration (managed in account/ root module).
+# provider: snowflake.sysadmin
+
+# ── SYNAPSE_RAW: main Parquet event/snapshot stage ────────────────────────────
+# Named {integration}_STAGE, e.g. SYNAPSE_PROD_WAREHOUSE_S3_STAGE (prod)
+# Receives: all Synapse snapshot and event Parquet files from S3.
+resource "snowflake_stage" "synapse_warehouse_s3" {
+  provider = snowflake.sysadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "${var.stage_storage_integration}_STAGE"
+
+  storage_integration = var.stage_storage_integration
+  url                 = var.stage_url
+  file_format         = "TYPE = PARQUET COMPRESSION = AUTO"
+  directory           = "ENABLE = TRUE"
+
+  depends_on = [snowflake_schema.synapse_raw]
+}
+
+# ── SYNAPSE_RAW: file-handle association stage ────────────────────────────────
+# Receives: file handle association Parquet records from S3.
+resource "snowflake_stage" "synapse_filehandles" {
+  provider = snowflake.sysadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "SYNAPSE_FILEHANDLES_STAGE"
+
+  storage_integration = var.stage_storage_integration
+  url                 = "s3://${var.stack}.filehandles.sagebase.org/fileHandleAssociations/records/"
+  file_format         = "TYPE = PARQUET COMPRESSION = AUTO"
+  directory           = "ENABLE = TRUE"
+
+  depends_on = [snowflake_schema.synapse_raw]
+}
+
+# ── RDS_LANDING: MySQL RDS snapshot Parquet stage ─────────────────────────────
+# Receives: RDS export Parquet files for the 2026 Synapse RDS → Snowflake pipeline (SNOW-392).
+resource "snowflake_stage" "rds_snapshots" {
+  provider = snowflake.sysadmin
+
+  database = var.database_name
+  schema   = "RDS_LANDING"
+  name     = "RDS_SNAPSHOTS_STAGE"
+
+  storage_integration = var.snapshots_stage_storage_integration
+  url                 = var.snapshots_stage_url
+  file_format         = "TYPE = PARQUET COMPRESSION = AUTO"
+  directory           = "ENABLE = TRUE"
+
+  depends_on = [snowflake_schema.rds_landing]
+}

--- a/terraform/modules/synapse_data_warehouse/streams.tf
+++ b/terraform/modules/synapse_data_warehouse/streams.tf
@@ -1,0 +1,44 @@
+# ── SYNAPSE_DATA_WAREHOUSE streams ────────────────────────────────────────────
+# Mirrors current stream state after all V__ migrations:
+#   Created: V1.13.0__create_streams.sql
+#   Modified: V2.2.0__recreate_certified_quiz_streams.sql (new source tables)
+#   Removed: V2.26.2__delete_nodesnapshots_stream.sql (NODESNAPSHOTS_STREAM dropped)
+#
+# Streams capture change data from snapshot tables and are consumed by merge
+# tasks (upsert_to_*_latest_task). Streams depend on the tables they monitor,
+# which are managed by schemachange — not Terraform.
+# provider: snowflake.sysadmin
+
+locals {
+  # Current active streams in SYNAPSE_RAW (NODESNAPSHOTS_STREAM was dropped in V2.26.2)
+  # Map of stream_name => source_table_name
+  synapse_raw_streams = {
+    ACLSNAPSHOTS_STREAM                    = "ACLSNAPSHOTS"
+    CERTIFIEDQUIZ_STREAM                   = "CERTIFIEDQUIZSNAPSHOTS"           # V2.2.0: now on CERTIFIEDQUIZSNAPSHOTS
+    CERTIFIEDQUIZQUESTION_STREAM           = "CERTIFIEDQUIZQUESTIONSNAPSHOTS"   # V2.2.0: now on CERTIFIEDQUIZQUESTIONSNAPSHOTS
+    USERPROFILESNAPSHOT_STREAM             = "USERPROFILESNAPSHOT"
+    TEAMMEMBERSNAPSHOTS_STREAM             = "TEAMMEMBERSNAPSHOTS"
+    FILESNAPSHOTS_STREAM                   = "FILESNAPSHOTS"
+    TEAMSNAPSHOTS_STREAM                   = "TEAMSNAPSHOTS"
+    USERGROUPSNAPSHOTS_STREAM              = "USERGROUPSNAPSHOTS"
+    VERIFICATIONSUBMISSIONSNAPSHOTS_STREAM = "VERIFICATIONSUBMISSIONSNAPSHOTS"
+  }
+}
+
+# Create each stream in the database managed by this module instance.
+resource "snowflake_stream_on_table" "synapse_raw" {
+  for_each = local.synapse_raw_streams
+
+  provider = snowflake.sysadmin
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = each.key
+
+  # Source table is managed by schemachange — reference by fully qualified name
+  table = "${var.database_name}.SYNAPSE_RAW.${each.value}"
+
+  # append_only = false (default): capture inserts, updates, and deletes
+  # show_initial_rows = false (default): only new changes after stream creation
+
+  depends_on = [snowflake_schema.synapse_raw]
+}

--- a/terraform/modules/synapse_data_warehouse/tasks.tf
+++ b/terraform/modules/synapse_data_warehouse/tasks.tf
@@ -1,0 +1,741 @@
+# ── SYNAPSE_DATA_WAREHOUSE tasks ───────────────────────────────────────────────
+# Represents the current active task DAG after all V__ migrations.
+# Dropped tasks are NOT included (see comments below for dropped tasks).
+#
+# DAG structure (SYNAPSE_RAW schema):
+#   refresh_synapse_warehouse_s3_stage_task  ← root, cron 23:00 daily LA time
+#     ├─ certifiedquiz_task
+#     │    └─ upsert_to_certifiedquiz_latest_task
+#     ├─ certifiedquizquestion_task          (leaf — downstream task dropped V2.29.1)
+#     ├─ nodesnapshot_task                   (leaf — downstream task dropped V2.26.1)
+#     ├─ filesnapshots_task                  (leaf — downstream task dropped V2.36.1)
+#     ├─ userprofilesnapshot_task            (leaf — downstream task dropped V2.30.1)
+#     ├─ teammembersnapshots_task            (leaf — downstream task dropped V2.42.1)
+#     ├─ aclsnapshots_task                   (leaf)
+#     ├─ teamsnapshots_task                  (leaf)
+#     ├─ usergroupsnapshots_task             (leaf)
+#     ├─ verificationsubmissionsnapshots_task (leaf)
+#     ├─ append_to_filehandleassociationsnapshots_task (leaf)
+#     ├─ append_to_fileinventory_task        (leaf)
+#     ├─ processedaccess_task
+#     │    ├─ clone_process_access_task
+#     │    └─ create_access_event_task
+#     ├─ filedownload_task
+#     │    └─ clone_filedownload_task
+#     └─ fileupload_task
+#          ├─ clone_fileupload_task
+#          └─ create_fileupload_event_task
+#
+# SYNAPSE schema:
+#   backup_synapse_data_warehouse_task  ← root, cron 03:00 Sundays LA time
+#     └─ revoke_backup_synapse_access   (started = false in both envs; resume prod manually)
+#
+# SQL bodies below reflect the latest ALTER TASK MODIFY AS state.
+# All tasks use USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE (serverless); no warehouse needed.
+# provider: snowflake.accountadmin (tasks were created with USE ROLE ACCOUNTADMIN in SQL)
+
+# ── Root task: stage refresh ──────────────────────────────────────────────────
+resource "snowflake_task" "refresh_stage" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"
+
+  user_task_managed_initial_warehouse_size = "SMALL"
+  schedule { using_cron = "0 23 * * * America/Los_Angeles" }
+  started = true
+
+  sql_statement = "ALTER STAGE IF EXISTS ${var.stage_storage_integration}_STAGE REFRESH"
+
+  depends_on = [snowflake_stage.synapse_warehouse_s3]
+}
+
+# ── Tier 1: COPY INTO tasks (after stage refresh) ─────────────────────────────
+
+resource "snowflake_task" "certifiedquiz" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "CERTIFIEDQUIZ_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO certifiedquiz
+    FROM (
+      SELECT
+        $1:response_id AS response_id,
+        $1:user_id AS user_id,
+        $1:passed AS passed,
+        $1:passed_on AS passed_on,
+        $1:stack AS stack,
+        $1:instance AS instance,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*certifiedquizrecords\\/record_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS record_date
+      FROM @${var.stage_storage_integration}_STAGE/certifiedquizrecords
+    )
+    PATTERN = '.*certifiedquizrecords/record_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "certifiedquizquestion" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "CERTIFIEDQUIZQUESTION_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO certifiedquizquestion
+    FROM (
+      SELECT
+        $1:response_id AS response_id,
+        $1:question_index AS question_index,
+        $1:is_correct AS is_correct,
+        $1:stack AS stack,
+        $1:instance AS instance,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*certifiedquizquestionrecords\\/record_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS record_date
+      FROM @${var.stage_storage_integration}_STAGE/certifiedquizquestionrecords
+    )
+    PATTERN = '.*certifiedquizquestionrecords/record_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "nodesnapshot" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "NODESNAPSHOT_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  # SQL body reflects V2.25.1 (adds version_history, annotations, derived_annotations, etc.)
+  sql_statement = <<-SQL
+    COPY INTO nodesnapshots
+    FROM (
+      SELECT
+        $1:change_type AS change_type,
+        $1:change_timestamp AS change_timestamp,
+        $1:change_user_id AS change_user_id,
+        $1:snapshot_timestamp AS snapshot_timestamp,
+        $1:id AS id,
+        $1:benefactor_id AS benefactor_id,
+        $1:project_id AS project_id,
+        $1:parent_id AS parent_id,
+        $1:node_type AS node_type,
+        $1:created_on AS created_on,
+        $1:created_by AS created_by,
+        $1:modified_on AS modified_on,
+        $1:modified_by AS modified_by,
+        $1:version_number AS version_number,
+        $1:file_handle_id AS file_handle_id,
+        $1:name AS name,
+        $1:is_public AS is_public,
+        $1:is_controlled AS is_controlled,
+        $1:is_restricted AS is_restricted,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*nodesnapshots\\/snapshot_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS snapshot_date,
+        $1:effective_ars AS effective_ars,
+        PARSE_JSON(REPLACE(REPLACE($1:annotations, '\n', '\\n'), '\r', '\\r')) AS annotations,
+        PARSE_JSON(REPLACE(REPLACE($1:derived_annotations, '\n', '\\n'), '\r', '\\r')) AS derived_annotations,
+        $1:version_comment AS version_comment,
+        $1:version_label AS version_label,
+        $1:alias AS alias,
+        $1:activity_id AS activity_id,
+        PARSE_JSON($1:column_model_ids) AS column_model_ids,
+        PARSE_JSON($1:scope_ids) AS scope_ids,
+        PARSE_JSON($1:items) AS items,
+        PARSE_JSON($1:reference) AS reference,
+        $1:is_search_enabled AS is_search_enabled,
+        $1:defining_sql AS defining_sql,
+        PARSE_JSON(REPLACE(REPLACE($1:internal_annotations, '\n', '\\n'), '\r', '\\r')) AS internal_annotations,
+        PARSE_JSON(REPLACE(REPLACE($1:version_history, '\n', '\\n'), '\r', '\\r')) AS version_history
+      FROM @${var.stage_storage_integration}_STAGE/nodesnapshots/
+    )
+    PATTERN = '.*nodesnapshots/snapshot_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "filesnapshots" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "FILESNAPSHOTS_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO filesnapshots
+    FROM (
+      SELECT
+        $1:change_type AS change_type,
+        $1:change_timestamp AS change_timestamp,
+        $1:change_user_id AS change_user_id,
+        $1:snapshot_timestamp AS snapshot_timestamp,
+        $1:id AS id,
+        $1:created_by AS created_by,
+        $1:created_on AS created_on,
+        $1:modified_on AS modified_on,
+        $1:concrete_type AS concrete_type,
+        $1:content_md5 AS content_md5,
+        $1:content_type AS content_type,
+        MD5($1:file_name) AS file_name,
+        $1:storage_location_id AS storage_location_id,
+        $1:content_size AS content_size,
+        $1:bucket AS bucket,
+        MD5($1:key) AS key,
+        $1:preview_id AS preview_id,
+        $1:is_preview AS is_preview,
+        $1:status AS status,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*filesnapshots\\/snapshot_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS snapshot_date
+      FROM @${var.stage_storage_integration}_STAGE/filesnapshots
+    )
+    PATTERN = '.*filesnapshots/snapshot_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "userprofilesnapshot" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "USERPROFILESNAPSHOT_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO userprofilesnapshot
+    FROM (
+      SELECT
+        $1:change_type AS change_type,
+        $1:change_timestamp AS change_timestamp,
+        $1:change_user_id AS change_user_id,
+        $1:snapshot_timestamp AS snapshot_timestamp,
+        $1:id AS id,
+        $1:user_name AS user_name,
+        $1:first_name AS first_name,
+        $1:last_name AS last_name,
+        REGEXP_REPLACE($1:email, '.+\\@', '*****@') AS email,
+        $1:location AS location,
+        $1:company AS company,
+        $1:position AS position,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*userprofilesnapshots\\/snapshot_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS snapshot_date
+      FROM @${var.stage_storage_integration}_STAGE/userprofilesnapshots
+    )
+    PATTERN = '.*userprofilesnapshots/snapshot_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "teammembersnapshots" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "TEAMMEMBERSNAPSHOTS_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO teammembersnapshots
+    FROM (
+      SELECT
+        $1:change_type AS change_type,
+        $1:change_timestamp AS change_timestamp,
+        $1:change_user_id AS change_user_id,
+        $1:snapshot_timestamp AS snapshot_timestamp,
+        $1:team_id AS team_id,
+        $1:member_id AS member_id,
+        $1:is_admin AS is_admin,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*teammembersnapshots\\/snapshot_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS snapshot_date
+      FROM @${var.stage_storage_integration}_STAGE/teammembersnapshots
+    )
+    PATTERN = '.*teammembersnapshots/snapshot_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "aclsnapshots" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "ACLSNAPSHOTS_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO aclsnapshots
+    FROM (
+      SELECT
+        $1:change_timestamp AS change_timestamp,
+        $1:change_type AS change_type,
+        $1:snapshot_timestamp AS snapshot_timestamp,
+        $1:owner_id AS owner_id,
+        $1:owner_type AS owner_type,
+        $1:created_on AS created_on,
+        $1:resource_access AS resource_access,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*aclsnapshots\\/snapshot_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS snapshot_date
+      FROM @${var.stage_storage_integration}_STAGE/aclsnapshots
+    )
+    PATTERN = '.*aclsnapshots/snapshot_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "teamsnapshots" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "TEAMSNAPSHOTS_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO teamsnapshots
+    FROM (
+      SELECT
+        $1:change_type AS change_type,
+        $1:change_timestamp AS change_timestamp,
+        $1:change_user_id AS change_user_id,
+        $1:snapshot_timestamp AS snapshot_timestamp,
+        $1:id AS id,
+        $1:name AS name,
+        $1:can_public_join AS can_public_join,
+        $1:created_on AS created_on,
+        $1:created_by AS created_by,
+        $1:modified_on AS modified_on,
+        $1:modified_by AS modified_by,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*teamsnapshots\\/snapshot_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS snapshot_date
+      FROM @${var.stage_storage_integration}_STAGE/teamsnapshots
+    )
+    PATTERN = '.*teamsnapshots/snapshot_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "usergroupsnapshots" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "USERGROUPSNAPSHOTS_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO usergroupsnapshots
+    FROM (
+      SELECT
+        $1:change_type AS change_type,
+        $1:change_timestamp AS change_timestamp,
+        $1:change_user_id AS change_user_id,
+        $1:snapshot_timestamp AS snapshot_timestamp,
+        $1:id AS id,
+        $1:is_individual AS is_individual,
+        $1:created_on AS created_on,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*usergroupsnapshots\\/snapshot_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS snapshot_date
+      FROM @${var.stage_storage_integration}_STAGE/usergroupsnapshots
+    )
+    PATTERN = '.*usergroupsnapshots/snapshot_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "verificationsubmissionsnapshots" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "VERIFICATIONSUBMISSIONSNAPSHOTS_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO verificationsubmissionsnapshots
+    FROM (
+      SELECT
+        $1:change_timestamp AS change_timestamp,
+        $1:change_type AS change_type,
+        $1:snapshot_timestamp AS snapshot_timestamp,
+        $1:id AS id,
+        $1:created_on AS created_on,
+        $1:created_by AS created_by,
+        $1:state_history AS state_history,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*verificationsubmissionsnapshots\\/snapshot_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS snapshot_date
+      FROM @${var.stage_storage_integration}_STAGE/verificationsubmissionsnapshots
+    )
+    PATTERN = '.*verificationsubmissionsnapshots/snapshot_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "processedaccess" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "PROCESSEDACCESS_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO processedaccess
+    FROM (
+      SELECT
+        $1:session_id AS session_id,
+        $1:timestamp AS timestamp,
+        $1:user_id AS user_id,
+        $1:method AS method,
+        $1:request_url AS request_url,
+        $1:user_agent AS user_agent,
+        $1:host AS host,
+        $1:origin AS origin,
+        $1:x_forwarded_for AS x_forwarded_for,
+        $1:via AS via,
+        $1:thread_id AS thread_id,
+        $1:elapse_ms AS elapse_ms,
+        $1:success AS success,
+        $1:stack AS stack,
+        $1:instance AS instance,
+        $1:vm_id AS vm_id,
+        $1:return_object_id AS return_object_id,
+        $1:query_string AS query_string,
+        $1:response_status AS response_status,
+        $1:oauth_client_id AS oauth_client_id,
+        $1:basic_auth_username AS basic_auth_username,
+        $1:auth_method AS auth_method,
+        $1:normalized_method_signature AS normalized_method_signature,
+        $1:client AS client,
+        $1:client_version AS client_version,
+        $1:entity_id AS entity_id,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*processedaccessrecord\\/record_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS record_date
+      FROM @${var.stage_storage_integration}_STAGE/processedaccessrecord
+    )
+    PATTERN = '.*processedaccessrecord/record_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "filedownload" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "FILEDOWNLOAD_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO filedownload
+    FROM (
+      SELECT
+        $1:timestamp AS timestamp,
+        $1:user_id AS user_id,
+        $1:project_id AS project_id,
+        $1:file_handle_id AS file_handle_id,
+        $1:downloaded_file_handle_id AS downloaded_file_handle_id,
+        $1:association_object_id AS association_object_id,
+        $1:association_object_type AS association_object_type,
+        $1:stack AS stack,
+        $1:instance AS instance,
+        $1:session_id AS session_id,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*filedownloadrecords\\/record_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS record_date
+      FROM @${var.stage_storage_integration}_STAGE/filedownloadrecords
+    )
+    PATTERN = '.*filedownloadrecords/record_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "fileupload" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "FILEUPLOAD_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO fileupload
+    FROM (
+      SELECT
+        $1:timestamp AS timestamp,
+        $1:user_id AS user_id,
+        $1:project_id AS project_id,
+        $1:file_handle_id AS file_handle_id,
+        $1:association_object_id AS association_object_id,
+        $1:association_object_type AS association_object_type,
+        $1:stack AS stack,
+        $1:instance AS instance,
+        NULLIF(
+          REGEXP_REPLACE(metadata$filename,
+            '.*fileuploadrecords\\/record_date\\=(.*)\\/.* ', '\\1'),
+          '__HIVE_DEFAULT_PARTITION__'
+        ) AS record_date
+      FROM @${var.stage_storage_integration}_STAGE/fileuploadrecords
+    )
+    PATTERN = '.*fileuploadrecords/record_date=.*/.*'
+  SQL
+}
+
+resource "snowflake_task" "append_filehandleassociationsnapshots" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "APPEND_TO_FILEHANDLEASSOCIATIONSNAPSHOTS_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    COPY INTO filehandleassociationsnapshots
+    FROM (
+      SELECT
+        $1:associateid AS associateid,
+        $1:associatetype AS associatetype,
+        $1:filehandleid AS filehandleid,
+        $1:instance AS instance,
+        $1:stack AS stack,
+        $1:timestamp AS timestamp
+      FROM @SYNAPSE_FILEHANDLES_STAGE
+    )
+  SQL
+
+  depends_on = [snowflake_stage.synapse_filehandles]
+}
+
+resource "snowflake_task" "append_fileinventory" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "APPEND_TO_FILEINVENTORY_TASK"
+  user_task_managed_initial_warehouse_size = "SMALL"
+  after   = ["REFRESH_SYNAPSE_WAREHOUSE_S3_STAGE_TASK"]
+  started = true
+
+  # SQL body from V2.12.2 (final ALTER TASK MODIFY AS — adds snapshot_date from file metadata)
+  sql_statement = <<-SQL
+    COPY INTO fileinventory
+    FROM (
+      SELECT
+        $1:bucket AS bucket,
+        $1:e_tag AS e_tag,
+        $1:encryption_status AS encryption_status,
+        $1:intelligent_tiering_access_tier AS intelligent_tiering_access_tier,
+        $1:is_delete_marker AS is_delete_marker,
+        $1:is_latest AS is_latest,
+        $1:is_multipart_uploaded AS is_multipart_uploaded,
+        $1:key AS key,
+        $1:last_modified_date AS last_modified_date,
+        $1:object_owner AS object_owner,
+        $1:size AS size,
+        $1:storage_class AS storage_class,
+        metadata$file_last_modified AS snapshot_date
+      FROM @${var.stage_storage_integration}_STAGE/inventory
+    )
+    PATTERN = '.*defaultInventory/data/.*'
+  SQL
+}
+
+# ── Tier 2: downstream tasks ──────────────────────────────────────────────────
+
+resource "snowflake_task" "upsert_certifiedquiz_latest" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "UPSERT_TO_CERTIFIEDQUIZ_LATEST_TASK"
+  user_task_managed_initial_warehouse_size = "XSMALL"
+  after   = ["CERTIFIEDQUIZ_TASK"]
+  started = true
+
+  sql_statement = <<-SQL
+    MERGE INTO ${var.database_name}.SYNAPSE.CERTIFIEDQUIZ_LATEST AS TARGET_TABLE
+    USING (
+      WITH CQQ_RANKED AS (
+        SELECT
+          *,
+          ROW_NUMBER() OVER (
+            PARTITION BY USER_ID
+            ORDER BY INSTANCE DESC, RESPONSE_ID DESC
+          ) AS ROW_NUM
+        FROM CERTIFIEDQUIZ_STREAM
+      )
+      SELECT * EXCLUDE ROW_NUM FROM CQQ_RANKED WHERE ROW_NUM = 1
+    ) AS SOURCE_TABLE ON TARGET_TABLE.USER_ID = SOURCE_TABLE.USER_ID
+    WHEN MATCHED THEN UPDATE SET
+      TARGET_TABLE.RESPONSE_ID = SOURCE_TABLE.RESPONSE_ID,
+      TARGET_TABLE.PASSED = SOURCE_TABLE.PASSED,
+      TARGET_TABLE.PASSED_ON = SOURCE_TABLE.PASSED_ON,
+      TARGET_TABLE.STACK = SOURCE_TABLE.STACK,
+      TARGET_TABLE.INSTANCE = SOURCE_TABLE.INSTANCE,
+      TARGET_TABLE.RECORD_DATE = SOURCE_TABLE.RECORD_DATE
+    WHEN NOT MATCHED THEN INSERT (RESPONSE_ID, USER_ID, PASSED, PASSED_ON, STACK, INSTANCE, RECORD_DATE)
+    VALUES (SOURCE_TABLE.RESPONSE_ID, SOURCE_TABLE.USER_ID, SOURCE_TABLE.PASSED, SOURCE_TABLE.PASSED_ON,
+            SOURCE_TABLE.STACK, SOURCE_TABLE.INSTANCE, SOURCE_TABLE.RECORD_DATE)
+  SQL
+}
+
+resource "snowflake_task" "clone_processedaccess" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "CLONE_PROCESS_ACCESS_TASK"
+  user_task_managed_initial_warehouse_size = "XSMALL"
+  after   = ["PROCESSEDACCESS_TASK"]
+  started = true
+
+  sql_statement = "CREATE OR REPLACE TABLE ${var.database_name}.SYNAPSE.PROCESSEDACCESS CLONE ${var.database_name}.SYNAPSE_RAW.PROCESSEDACCESS"
+}
+
+resource "snowflake_task" "clone_filedownload" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "CLONE_FILEDOWNLOAD_TASK"
+  user_task_managed_initial_warehouse_size = "XSMALL"
+  after   = ["FILEDOWNLOAD_TASK"]
+  started = true
+
+  sql_statement = "CREATE OR REPLACE TABLE ${var.database_name}.SYNAPSE.FILEDOWNLOAD CLONE ${var.database_name}.SYNAPSE_RAW.FILEDOWNLOAD"
+}
+
+resource "snowflake_task" "clone_fileupload" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "CLONE_FILEUPLOAD_TASK"
+  user_task_managed_initial_warehouse_size = "XSMALL"
+  after   = ["FILEUPLOAD_TASK"]
+  started = true
+
+  sql_statement = "CREATE OR REPLACE TABLE ${var.database_name}.SYNAPSE.FILEUPLOAD CLONE ${var.database_name}.SYNAPSE_RAW.FILEUPLOAD"
+}
+
+resource "snowflake_task" "create_fileupload_event" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "CREATE_FILEUPLOAD_EVENT_TASK"
+  user_task_managed_initial_warehouse_size = "XSMALL"
+  after   = ["FILEUPLOAD_TASK"]
+  started = true
+
+  sql_statement = "CREATE OR REPLACE TABLE ${var.database_name}.SYNAPSE_EVENT.FILEUPLOAD_EVENT CLONE ${var.database_name}.SYNAPSE_RAW.FILEUPLOAD"
+
+  depends_on = [snowflake_schema.synapse_event]
+}
+
+resource "snowflake_task" "create_access_event" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE_RAW"
+  name     = "CREATE_ACCESS_EVENT_TASK"
+  user_task_managed_initial_warehouse_size = "XSMALL"
+  after   = ["PROCESSEDACCESS_TASK"]
+  started = true
+
+  sql_statement = "CREATE OR REPLACE TABLE ${var.database_name}.SYNAPSE_EVENT.ACCESS_EVENT CLONE ${var.database_name}.SYNAPSE_RAW.PROCESSEDACCESS"
+
+  depends_on = [snowflake_schema.synapse_event]
+}
+
+# ── SYNAPSE schema: backup task (V2.59.0) ─────────────────────────────────────
+# Runs weekly (Sundays 03:00 LA) to clone the prod database.
+# started = false — comment in V2.59.0 notes prod resume must be done manually;
+# dev should also remain suspended to avoid unnecessary clones.
+
+resource "snowflake_task" "backup_synapse_data_warehouse" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE"
+  name     = "BACKUP_SYNAPSE_DATA_WAREHOUSE_TASK"
+  user_task_managed_initial_warehouse_size = "XSMALL"
+  schedule { using_cron = "0 3 * * 0 America/Los_Angeles" }
+  started = false  # Resume manually in prod only (see V2.59.0 comment)
+
+  sql_statement = "CREATE OR REPLACE DATABASE BACKUP_SYNAPSE_DATA_WAREHOUSE CLONE SYNAPSE_DATA_WAREHOUSE"
+
+  depends_on = [snowflake_schema.synapse]
+}
+
+resource "snowflake_task" "revoke_backup_synapse_access" {
+  provider = snowflake.accountadmin
+
+  database = var.database_name
+  schema   = "SYNAPSE"
+  name     = "REVOKE_BACKUP_SYNAPSE_ACCESS"
+  user_task_managed_initial_warehouse_size = "XSMALL"
+  after   = ["BACKUP_SYNAPSE_DATA_WAREHOUSE_TASK"]
+  started = false  # Controlled by parent task resumed state
+
+  sql_statement = "REVOKE USAGE ON DATABASE BACKUP_SYNAPSE_DATA_WAREHOUSE FROM ROLE SYNAPSE_DATA_WAREHOUSE_ANALYST"
+}

--- a/terraform/modules/synapse_data_warehouse/variables.tf
+++ b/terraform/modules/synapse_data_warehouse/variables.tf
@@ -1,0 +1,47 @@
+# ── Per-environment configuration ────────────────────────────────────────────
+# These map directly to the sdw_databases local in the old flat structure.
+
+variable "database_name" {
+  description = "Snowflake database managed by this module instance (e.g. SYNAPSE_DATA_WAREHOUSE or SYNAPSE_DATA_WAREHOUSE_DEV)"
+  type        = string
+}
+
+variable "stage_storage_integration" {
+  description = "Name of the storage integration for the main Synapse S3 stage (e.g. SYNAPSE_PROD_WAREHOUSE_S3)"
+  type        = string
+}
+
+variable "stage_url" {
+  description = "S3 URL for the main Synapse event/snapshot external stage"
+  type        = string
+}
+
+variable "snapshots_stage_storage_integration" {
+  description = "Name of the storage integration for the RDS-snapshot stage (e.g. SYNAPSE_SNAPSHOTS_PROD)"
+  type        = string
+}
+
+variable "snapshots_stage_url" {
+  description = "S3 URL for the RDS-snapshot external stage"
+  type        = string
+}
+
+variable "stack" {
+  description = "Stack identifier used in S3 URLs — 'prod' or 'dev'"
+  type        = string
+}
+
+variable "admin_role" {
+  description = "Account role that receives SYNAPSE_*_ALL_ADMIN database roles (e.g. SYNAPSE_DATA_WAREHOUSE_ADMIN)"
+  type        = string
+}
+
+variable "analyst_role" {
+  description = "Account role that receives SYNAPSE_*_ALL_ANALYST database roles (e.g. SYNAPSE_DATA_WAREHOUSE_ANALYST)"
+  type        = string
+}
+
+variable "proxy_admin_role" {
+  description = "Account role that owns the ALL_ADMIN database role (e.g. SYNAPSE_DATA_WAREHOUSE_PROXY_ADMIN)"
+  type        = string
+}

--- a/terraform/synapse_data_warehouse/main.tf
+++ b/terraform/synapse_data_warehouse/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    snowflake = {
+      source  = "Snowflake-Labs/snowflake"
+      version = "~> 1.0"
+    }
+  }
+
+  cloud {
+    organization = "sage-bionetworks"
+    workspaces {
+      name = "snowflake-sdw"
+    }
+  }
+}
+
+# All three providers are passed into the reusable SDW module.
+# No resources are defined directly in this root module.
+
+provider "snowflake" {
+  alias                  = "sysadmin"
+  organization_name      = var.snowflake_organization_name
+  account_name           = var.snowflake_account_name
+  user                   = var.snowflake_user
+  authenticator          = "SNOWFLAKE_JWT"
+  private_key            = var.snowflake_private_key
+  private_key_passphrase = var.snowflake_private_key_passphrase
+  role                   = "SYSADMIN"
+}
+
+provider "snowflake" {
+  alias                  = "securityadmin"
+  organization_name      = var.snowflake_organization_name
+  account_name           = var.snowflake_account_name
+  user                   = var.snowflake_user
+  authenticator          = "SNOWFLAKE_JWT"
+  private_key            = var.snowflake_private_key
+  private_key_passphrase = var.snowflake_private_key_passphrase
+  role                   = "SECURITYADMIN"
+}
+
+provider "snowflake" {
+  alias                  = "accountadmin"
+  organization_name      = var.snowflake_organization_name
+  account_name           = var.snowflake_account_name
+  user                   = var.snowflake_user
+  authenticator          = "SNOWFLAKE_JWT"
+  private_key            = var.snowflake_private_key
+  private_key_passphrase = var.snowflake_private_key_passphrase
+  role                   = "ACCOUNTADMIN"
+}

--- a/terraform/synapse_data_warehouse/sdw.tf
+++ b/terraform/synapse_data_warehouse/sdw.tf
@@ -1,0 +1,44 @@
+# ── SYNAPSE_DATA_WAREHOUSE environments ───────────────────────────────────────
+# The reusable module is instantiated once for prod and once for dev.
+# Each call receives environment-specific values; all resource definitions live
+# in modules/synapse_data_warehouse/.
+
+module "prod" {
+  source = "../modules/synapse_data_warehouse"
+
+  providers = {
+    snowflake.sysadmin      = snowflake.sysadmin
+    snowflake.securityadmin = snowflake.securityadmin
+    snowflake.accountadmin  = snowflake.accountadmin
+  }
+
+  database_name                       = "SYNAPSE_DATA_WAREHOUSE"
+  stage_storage_integration           = "SYNAPSE_PROD_WAREHOUSE_S3"
+  stage_url                           = var.synapse_prod_stage_url
+  snapshots_stage_storage_integration = "SYNAPSE_SNAPSHOTS_PROD"
+  snapshots_stage_url                 = var.synapse_snapshots_prod_stage_url
+  stack                               = "prod"
+  admin_role                          = "SYNAPSE_DATA_WAREHOUSE_ADMIN"
+  analyst_role                        = "SYNAPSE_DATA_WAREHOUSE_ANALYST"
+  proxy_admin_role                    = "SYNAPSE_DATA_WAREHOUSE_PROXY_ADMIN"
+}
+
+module "dev" {
+  source = "../modules/synapse_data_warehouse"
+
+  providers = {
+    snowflake.sysadmin      = snowflake.sysadmin
+    snowflake.securityadmin = snowflake.securityadmin
+    snowflake.accountadmin  = snowflake.accountadmin
+  }
+
+  database_name                       = "SYNAPSE_DATA_WAREHOUSE_DEV"
+  stage_storage_integration           = "SYNAPSE_DEV_WAREHOUSE_S3"
+  stage_url                           = var.synapse_dev_stage_url
+  snapshots_stage_storage_integration = "SYNAPSE_SNAPSHOTS_DEV"
+  snapshots_stage_url                 = var.synapse_snapshots_dev_stage_url
+  stack                               = "dev"
+  admin_role                          = "SYNAPSE_DATA_WAREHOUSE_DEV_ADMIN"
+  analyst_role                        = "SYNAPSE_DATA_WAREHOUSE_DEV_ANALYST"
+  proxy_admin_role                    = "SYNAPSE_DATA_WAREHOUSE_DEV_PROXY_ADMIN"
+}

--- a/terraform/synapse_data_warehouse/variables.tf
+++ b/terraform/synapse_data_warehouse/variables.tf
@@ -1,0 +1,53 @@
+# ── Snowflake connection ──────────────────────────────────────────────────────
+
+variable "snowflake_organization_name" {
+  description = "Snowflake organization name — first segment of the account locator (e.g. 'MQZFHLD')"
+  type        = string
+}
+
+variable "snowflake_account_name" {
+  description = "Snowflake account name — second segment of the account locator (e.g. 'VP00034')"
+  type        = string
+}
+
+variable "snowflake_user" {
+  description = "Snowflake user to authenticate as (ADMIN_SERVICE for most operations)"
+  type        = string
+}
+
+variable "snowflake_private_key" {
+  description = "PEM-encoded RSA private key for key-pair authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "snowflake_private_key_passphrase" {
+  description = "Passphrase for the encrypted private key; omit if key is unencrypted"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+# ── SYNAPSE_DATA_WAREHOUSE stage URLs ─────────────────────────────────────────
+# These correspond to SNOWFLAKE_SYNAPSE_STAGE_URL / SNOWFLAKE_SNAPSHOTS_STAGE_URL
+# env vars used by schemachange.  Passed in from GitHub Secrets / HCP Terraform.
+
+variable "synapse_prod_stage_url" {
+  description = "S3 URL for the prod Synapse event/snapshot external stage (SNOWFLAKE_SYNAPSE_STAGE_URL prod)"
+  type        = string
+}
+
+variable "synapse_dev_stage_url" {
+  description = "S3 URL for the dev Synapse event/snapshot external stage (SNOWFLAKE_SYNAPSE_STAGE_URL dev)"
+  type        = string
+}
+
+variable "synapse_snapshots_prod_stage_url" {
+  description = "S3 URL for the prod RDS-snapshot external stage (SNOWFLAKE_SNAPSHOTS_STAGE_URL prod)"
+  type        = string
+}
+
+variable "synapse_snapshots_dev_stage_url" {
+  description = "S3 URL for the dev RDS-snapshot external stage (SNOWFLAKE_SNAPSHOTS_STAGE_URL dev)"
+  type        = string
+}


### PR DESCRIPTION
<!-- REQUIRED -->
<!-- The title of this PR must be prefixed with the Jira ticket -->
<!-- e.g., "[] My brief title" -->
# Problem
<!-- Describe the specific technical problem that this PR solves. -->
Currently, we use schema change to manage all of our resources, which is more of a database migration system and NOT a declarative way of managing our snowflake resources.  

<!-- REQUIRED -->

<!-- OPTIONAL -->
<!-- A brief description of the *technical* or *implementation* aspects of the problem -->
<!-- (Most or all contextual information about the problem should already be in Jira) -->

# Solution
<!-- Describe the specific technical solution that this PR provides -->

<!-- REQUIRED -->
<!-- For each of the acceptance criteria specified in the Jira ticket, describe how this criterion was addressed. -->
<!-- If you feel that it helps with clarity, provide links to specific lines within your changes. -->
On a high level, there are three ways to managing devOps for snowflake

1. schemachange (iterate on exsiting infrastructure).  However, for more declarative operations, we could look into R__ scripts, which are triggered alphabetically. All R scripts are only triggered based on if there has been a change in the file itself, which is extremely helpful.  The "state" is managed within snowflake tables.
     * R__001_identify.sql
     * R__002_infrastructure.sql
     * R__003_database.sql
2. Pulumi - https://www.pulumi.com/registry/packages/snowflake/.  Similar to AWS CDK, this is a python based way of managing infrastructure as code. There is a "state" file that will require to be managed
3. Terraform- https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs. Terraform has a snowflake provider that allows for managing infrastructure as code.  There is also a "state" file that is required to be managed.
4. Snowflake native devOps - Snowflake introduced `CREATE OR ALTER` commands, which would allow for us to track certain resources https://docs.snowflake.com/en/sql-reference/sql/create-or-alter, however, this does _not_ include storage locations and other important resources we may want to track in a declaritive way.

This PR showcases the resources Claude code generates on how we could manage resources. There is a "statE" file that will require to be managed

<!-- OPTIONAL -->
<!-- Describe any additional changes made that aren't relevant to the acceptance criteria. -->
<!-- Provide additional information that could help reviewers understand these changes and any potential side effects. -->

<!-- LINKING TO CODE -->
<!-- See official documentation -->
<!-- https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet -->

# Testing
<!-- Describe any testing that was performed to validate the solution. -->
NA, I have not tested this as this is a POC.
<!-- REQUIRED -->
<!-- Describe how changes were tested and provide *reproducible* and *self-contained* code blocks -->
<!-- That is, reviewers ought to be able to run the test code as-is in a new worksheet  -->
<!-- If changes cannot be tested (e.g., some account-level changes), briefly explain why this is the case -->

<!-- OPTIONAL -->
<!-- Link to automated tests -->
<!-- Provide additional information that could give reviewers further confidence in your solution --> 
