### PR TITLE
[SNOW-415] Add `submission_type` to data access submission model

### DIFF
--- a/transform/models/intermediate/synapse/_synapse__models.yml
+++ b/transform/models/intermediate/synapse/_synapse__models.yml
@@ -151,9 +151,6 @@ models:
         data_type: VARCHAR
         constraints:
           - type: not_null
-      - name: submission_type
-        description: "Submission classification. One of: 'new', 'update', or 'annual renewal'."
-        data_type: VARCHAR
       - name: state_reason
         description: "UTF-8 encoded string containing an explanation for the current state, particularly for rejections or cancellations. Null for records before 2019 due to invalid utf-8 characters."
         data_type: VARCHAR
@@ -232,6 +229,9 @@ models:
         data_type: VARCHAR
         constraints:
           - type: not_null
+      - name: submission_type
+        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'."
+        data_type: VARCHAR
       - name: state_reason
         description: "UTF-8 encoded string containing an explanation for the current state, particularly for rejections or cancellations. Null for records before 2019 due to invalid utf-8 characters."
         data_type: VARCHAR

--- a/transform/models/intermediate/synapse/_synapse__models.yml
+++ b/transform/models/intermediate/synapse/_synapse__models.yml
@@ -151,6 +151,9 @@ models:
         data_type: VARCHAR
         constraints:
           - type: not_null
+      - name: submission_type
+        description: "Submission classification. One of: 'new', 'update', or 'annual renewal'."
+        data_type: VARCHAR
       - name: state_reason
         description: "UTF-8 encoded string containing an explanation for the current state, particularly for rejections or cancellations. Null for records before 2019 due to invalid utf-8 characters."
         data_type: VARCHAR

--- a/transform/models/intermediate/synapse/_synapse__models.yml
+++ b/transform/models/intermediate/synapse/_synapse__models.yml
@@ -147,7 +147,7 @@ models:
         constraints:
           - type: not_null
       - name: state
-        description: "Current state in the submission workflow. One of: 'SUBMITTED', 'APPROVED', 'REJECTED', 'CANCELLED'"
+        description: "Current state in the submission workflow. One of: 'Submitted', 'Approved', 'Rejected', 'Cancelled'"
         data_type: VARCHAR
         constraints:
           - type: not_null
@@ -225,7 +225,7 @@ models:
         constraints:
           - type: not_null
       - name: state
-        description: "Current state in the submission workflow. One of: 'SUBMITTED', 'APPROVED', 'REJECTED', 'CANCELLED'"
+        description: "Current state in the submission workflow. One of: 'Submitted', 'Approved', 'Rejected', 'Cancelled'"
         data_type: VARCHAR
         constraints:
           - type: not_null

--- a/transform/models/intermediate/synapse/_synapse__models.yml
+++ b/transform/models/intermediate/synapse/_synapse__models.yml
@@ -230,8 +230,10 @@ models:
         constraints:
           - type: not_null
       - name: submission_type
-        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'. A record is 'New' when it is the first submission for the data access request or when no previously approved submission exists for that request. A record is 'Update' when a previously approved submission exists and its most recent approved state_modified_on is less than 10 months before the current submission created_on. A record is 'Annual Renewal' when a previously approved submission exists and its most recent approved state_modified_on is 10 or more months before the current submission created_on."
+        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'. A submission is 'New' when it is the first submission for the data access request or when no previously approved submission exists for that request. A submission is 'Update' when the most recently approved submission associated with the data access request was approved less than 10 months before the current submission was created. A submission is 'Annual Renewal' when the most recently approved submission associated with the data access request was approved more than 10 months before this submission was created."
         data_type: VARCHAR
+        constraints:
+          - type: not_null
       - name: state_reason
         description: "UTF-8 encoded string containing an explanation for the current state, particularly for rejections or cancellations. Null for records before 2019 due to invalid utf-8 characters."
         data_type: VARCHAR

--- a/transform/models/intermediate/synapse/_synapse__models.yml
+++ b/transform/models/intermediate/synapse/_synapse__models.yml
@@ -230,7 +230,7 @@ models:
         constraints:
           - type: not_null
       - name: submission_type
-        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'."
+        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'. A record is 'New' when it is the first submission for the data access request or when no previously approved submission exists for that request. A record is 'Update' when a previously approved submission exists and its most recent approved state_modified_on is less than 10 months before the current submission created_on. A record is 'Annual Renewal' when a previously approved submission exists and its most recent approved state_modified_on is 10 or more months before the current submission created_on."
         data_type: VARCHAR
       - name: state_reason
         description: "UTF-8 encoded string containing an explanation for the current state, particularly for rejections or cancellations. Null for records before 2019 due to invalid utf-8 characters."

--- a/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
+++ b/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
@@ -18,6 +18,35 @@ WITH base AS (
         data_access_submission_raw
     FROM {{ ref('int_synapse_data_access_submission') }}
 ),
+submission_types AS (
+    SELECT
+        data_access_submission_id,
+        CASE
+            WHEN submission_sequence = 1 THEN 'new'
+            WHEN most_recent_previously_approved_state_modified_on IS NULL THEN 'new'
+            WHEN DATEDIFF(
+                month,
+                most_recent_previously_approved_state_modified_on,
+                created_on
+            ) < 10 THEN 'update'
+            ELSE 'annual renewal'
+        END AS submission_type
+    FROM (
+        SELECT
+            data_access_submission_id,
+            created_on,
+            ROW_NUMBER() OVER (
+                PARTITION BY data_access_request_id
+                ORDER BY created_on, data_access_submission_id
+            ) AS submission_sequence,
+            MAX(CASE WHEN state = 'APPROVED' THEN state_modified_on END) OVER (
+                PARTITION BY data_access_request_id
+                ORDER BY created_on, data_access_submission_id
+                ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+            ) AS most_recent_previously_approved_state_modified_on
+        FROM base
+    ) base
+),
 principal_usernames AS (
     SELECT
         principal_id,
@@ -38,10 +67,13 @@ SELECT
     pa_modified.alias_display AS state_modified_by_user_name,
     base.state_modified_on,
     base.state,
+    submission_types.submission_type,
     base.state_reason,
     base.accessor_changes,
     base.data_access_submission_raw
 FROM base
+LEFT JOIN submission_types
+    ON base.data_access_submission_id = submission_types.data_access_submission_id
 LEFT JOIN principal_usernames pa_created
     ON base.created_by = pa_created.principal_id
 LEFT JOIN principal_usernames pa_modified

--- a/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
+++ b/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
@@ -22,14 +22,14 @@ submission_types AS (
     SELECT
         data_access_submission_id,
         CASE
-            WHEN submission_sequence = 1 THEN 'new'
-            WHEN most_recent_previously_approved_state_modified_on IS NULL THEN 'new'
+            WHEN submission_sequence = 1 THEN 'New'
+            WHEN most_recent_previously_approved_state_modified_on IS NULL THEN 'New'
             WHEN DATEDIFF(
                 month,
                 most_recent_previously_approved_state_modified_on,
                 created_on
-            ) < 10 THEN 'update'
-            ELSE 'annual renewal'
+            ) < 10 THEN 'Update'
+            ELSE 'Annual Renewal'
         END AS submission_type
     FROM (
         SELECT

--- a/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
+++ b/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
@@ -39,7 +39,7 @@ submission_types AS (
                 PARTITION BY data_access_request_id
                 ORDER BY created_on, data_access_submission_id
             ) AS submission_sequence,
-            MAX(CASE WHEN state = 'APPROVED' THEN state_modified_on END) OVER (
+            MAX(CASE WHEN state = 'Approved' THEN state_modified_on END) OVER (
                 PARTITION BY data_access_request_id
                 ORDER BY created_on, data_access_submission_id
                 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING

--- a/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
+++ b/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
@@ -37,12 +37,12 @@ submission_types AS (
             created_on,
             ROW_NUMBER() OVER (
                 PARTITION BY data_access_request_id
-                ORDER BY created_on, data_access_submission_id
+                ORDER BY created_on ASC, data_access_submission_id ASC
             ) AS submission_sequence,
             -- Take the `state_modified_on` of the most recently approved request
             MAX(CASE WHEN state = 'Approved' THEN state_modified_on END) OVER (
                 PARTITION BY data_access_request_id
-                ORDER BY created_on, data_access_submission_id
+                ORDER BY created_on ASC, data_access_submission_id ASC
                 -- Consider all previous requests, but NOT the current request
                 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
             ) AS most_recent_previously_approved_state_modified_on

--- a/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
+++ b/transform/models/intermediate/synapse/int_synapse_data_access_submission_enriched.sql
@@ -39,9 +39,11 @@ submission_types AS (
                 PARTITION BY data_access_request_id
                 ORDER BY created_on, data_access_submission_id
             ) AS submission_sequence,
+            -- Take the `state_modified_on` of the most recently approved request
             MAX(CASE WHEN state = 'Approved' THEN state_modified_on END) OVER (
                 PARTITION BY data_access_request_id
                 ORDER BY created_on, data_access_submission_id
+                -- Consider all previous requests, but NOT the current request
                 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
             ) AS most_recent_previously_approved_state_modified_on
         FROM base

--- a/transform/models/marts/sage/_sage__models.yml
+++ b/transform/models/marts/sage/_sage__models.yml
@@ -49,6 +49,9 @@ models:
       - name: submission_status
         description: "Current state in the submission workflow. One of: 'SUBMITTED', 'APPROVED', 'REJECTED', 'CANCELLED'"
         data_type: VARCHAR
+      - name: submission_type
+        description: "Submission classification. One of: 'new', 'update', or 'annual renewal'."
+        data_type: VARCHAR
       - name: reviewed_by
         description: "Identifier of the user who last modified the submission status."
         data_type: NUMBER

--- a/transform/models/marts/sage/_sage__models.yml
+++ b/transform/models/marts/sage/_sage__models.yml
@@ -50,7 +50,7 @@ models:
         description: "Current state in the submission workflow. One of: 'SUBMITTED', 'APPROVED', 'REJECTED', 'CANCELLED'"
         data_type: VARCHAR
       - name: submission_type
-        description: "Submission classification. One of: 'new', 'update', or 'annual renewal'."
+        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'."
         data_type: VARCHAR
       - name: reviewed_by
         description: "Identifier of the user who last modified the submission status."

--- a/transform/models/marts/sage/_sage__models.yml
+++ b/transform/models/marts/sage/_sage__models.yml
@@ -47,7 +47,7 @@ models:
         description: "The submission attempt number within the current approval cycle for this data access request."
         data_type: NUMBER
       - name: submission_status
-        description: "Current state in the submission workflow. One of: 'SUBMITTED', 'APPROVED', 'REJECTED', 'CANCELLED'"
+        description: "Current state in the submission workflow. One of: 'Submitted', 'Approved', 'Rejected', 'Cancelled'"
         data_type: VARCHAR
       - name: submission_type
         description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'."

--- a/transform/models/marts/sage/_sage__models.yml
+++ b/transform/models/marts/sage/_sage__models.yml
@@ -50,7 +50,7 @@ models:
         description: "Current state in the submission workflow. One of: 'Submitted', 'Approved', 'Rejected', 'Cancelled'"
         data_type: VARCHAR
       - name: submission_type
-        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'."
+        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'. A record is 'New' when it is the first submission for the data access request or when no previously approved submission exists for that request. A record is 'Update' when a previously approved submission exists and its most recent approved state_modified_on is less than 10 months before the current submission created_on. A record is 'Annual Renewal' when a previously approved submission exists and its most recent approved state_modified_on is 10 or more months before the current submission created_on."
         data_type: VARCHAR
       - name: reviewed_by
         description: "Identifier of the user who last modified the submission status."

--- a/transform/models/marts/sage/_sage__models.yml
+++ b/transform/models/marts/sage/_sage__models.yml
@@ -50,8 +50,10 @@ models:
         description: "Current state in the submission workflow. One of: 'Submitted', 'Approved', 'Rejected', 'Cancelled'"
         data_type: VARCHAR
       - name: submission_type
-        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'. A record is 'New' when it is the first submission for the data access request or when no previously approved submission exists for that request. A record is 'Update' when a previously approved submission exists and its most recent approved state_modified_on is less than 10 months before the current submission created_on. A record is 'Annual Renewal' when a previously approved submission exists and its most recent approved state_modified_on is 10 or more months before the current submission created_on."
+        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'. A submission is 'New' when it is the first submission for the data access request or when no previously approved submission exists for that request. A submission is 'Update' when the most recently approved submission associated with the data access request was approved less than 10 months before the current submission was created. A submission is 'Annual Renewal' when the most recently approved submission associated with the data access request was approved more than 10 months before this submission was created."
         data_type: VARCHAR
+        constraints:
+          - type: not_null
       - name: reviewed_by
         description: "Identifier of the user who last modified the submission status."
         data_type: NUMBER

--- a/transform/models/marts/sage/data_access_submission_dashboard.sql
+++ b/transform/models/marts/sage/data_access_submission_dashboard.sql
@@ -13,6 +13,7 @@ WITH base AS (
         state_modified_by_user_name,
         state_modified_on,
         state,
+        submission_type,
         state_reason,
         accessor_changes,
         data_access_submission_raw
@@ -50,6 +51,7 @@ SELECT
     base.created_on as submitted_on,
     attempts.attempt,
     base.state as submission_status,
+    base.submission_type,
     base.state_modified_by as reviewed_by,
     state_modified_by_user_name as reviewed_by_user_name,
     base.state_modified_on as reviewed_on,

--- a/transform/models/marts/sage/data_access_submission_dashboard.sql
+++ b/transform/models/marts/sage/data_access_submission_dashboard.sql
@@ -23,7 +23,7 @@ approval_cycles AS (
     SELECT
         data_access_submission_id,
         COALESCE(
-            SUM(CASE WHEN state = 'APPROVED' THEN 1 ELSE 0 END) 
+            SUM(CASE WHEN state = 'Approved' THEN 1 ELSE 0 END) 
                 OVER (PARTITION BY data_access_request_id ORDER BY created_on ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING),
             0
         ) AS approval_cycle

--- a/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
+++ b/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
@@ -59,6 +59,9 @@ models:
       - name: state
         description: "Current state in the submission workflow. One of: 'SUBMITTED', 'APPROVED', 'REJECTED', 'CANCELLED'"
         data_type: VARCHAR
+      - name: submission_type
+        description: "Submission classification. One of: 'new', 'update', or 'annual renewal'."
+        data_type: VARCHAR
       - name: state_reason
         description: "UTF-8 encoded string containing an explanation for the current state, particularly for rejections or cancellations. Null for records before 2019 due to invalid utf-8 characters."
         data_type: VARCHAR

--- a/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
+++ b/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
@@ -57,7 +57,7 @@ models:
         description: "UTC timestamp when the submission status was last modified."
         data_type: TIMESTAMP_NTZ
       - name: state
-        description: "Current state in the submission workflow. One of: 'SUBMITTED', 'APPROVED', 'REJECTED', 'CANCELLED'"
+        description: "Current state in the submission workflow. One of: 'Submitted', 'Approved', 'Rejected', 'Cancelled'"
         data_type: VARCHAR
       - name: submission_type
         description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'."

--- a/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
+++ b/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
@@ -60,7 +60,7 @@ models:
         description: "Current state in the submission workflow. One of: 'SUBMITTED', 'APPROVED', 'REJECTED', 'CANCELLED'"
         data_type: VARCHAR
       - name: submission_type
-        description: "Submission classification. One of: 'new', 'update', or 'annual renewal'."
+        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'."
         data_type: VARCHAR
       - name: state_reason
         description: "UTF-8 encoded string containing an explanation for the current state, particularly for rejections or cancellations. Null for records before 2019 due to invalid utf-8 characters."

--- a/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
+++ b/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
@@ -60,7 +60,7 @@ models:
         description: "Current state in the submission workflow. One of: 'Submitted', 'Approved', 'Rejected', 'Cancelled'"
         data_type: VARCHAR
       - name: submission_type
-        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'."
+        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'. A record is 'New' when it is the first submission for the data access request or when no previously approved submission exists for that request. A record is 'Update' when a previously approved submission exists and its most recent approved state_modified_on is less than 10 months before the current submission created_on. A record is 'Annual Renewal' when a previously approved submission exists and its most recent approved state_modified_on is 10 or more months before the current submission created_on."
         data_type: VARCHAR
       - name: state_reason
         description: "UTF-8 encoded string containing an explanation for the current state, particularly for rejections or cancellations. Null for records before 2019 due to invalid utf-8 characters."

--- a/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
+++ b/transform/models/marts/synapse_data_warehouse/_synapse_data_warehouse__models.yml
@@ -60,8 +60,10 @@ models:
         description: "Current state in the submission workflow. One of: 'Submitted', 'Approved', 'Rejected', 'Cancelled'"
         data_type: VARCHAR
       - name: submission_type
-        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'. A record is 'New' when it is the first submission for the data access request or when no previously approved submission exists for that request. A record is 'Update' when a previously approved submission exists and its most recent approved state_modified_on is less than 10 months before the current submission created_on. A record is 'Annual Renewal' when a previously approved submission exists and its most recent approved state_modified_on is 10 or more months before the current submission created_on."
+        description: "Submission classification. One of: 'New', 'Update', or 'Annual Renewal'. A submission is 'New' when it is the first submission for the data access request or when no previously approved submission exists for that request. A submission is 'Update' when the most recently approved submission associated with the data access request was approved less than 10 months before the current submission was created. A submission is 'Annual Renewal' when the most recently approved submission associated with the data access request was approved more than 10 months before this submission was created."
         data_type: VARCHAR
+        constraints:
+          - type: not_null
       - name: state_reason
         description: "UTF-8 encoded string containing an explanation for the current state, particularly for rejections or cancellations. Null for records before 2019 due to invalid utf-8 characters."
         data_type: VARCHAR

--- a/transform/models/marts/synapse_data_warehouse/data_access_submission_event.sql
+++ b/transform/models/marts/synapse_data_warehouse/data_access_submission_event.sql
@@ -11,6 +11,7 @@ select
     state_modified_by_user_name,
     state_modified_on,
     state,
+    submission_type,
     state_reason,
     accessor_changes,
     data_access_submission_raw

--- a/transform/models/staging/synapse/_synapse__models.yml
+++ b/transform/models/staging/synapse/_synapse__models.yml
@@ -502,7 +502,7 @@ models:
         constraints:
           - type: not_null
       - name: state
-        description: "Current state in the submission workflow. One of: 'SUBMITTED', 'APPROVED', 'REJECTED', 'CANCELLED'"
+        description: "Current state in the submission workflow. One of: 'Submitted', 'Approved', 'Rejected', 'Cancelled'"
         data_type: VARCHAR
         constraints:
           - type: not_null

--- a/transform/models/staging/synapse/stg_synapse__data_access_submission_status.sql
+++ b/transform/models/staging/synapse/stg_synapse__data_access_submission_status.sql
@@ -15,7 +15,7 @@ staging as (
         to_timestamp(created_on/1000) as created_on,
         modified_by as state_modified_by,
         to_timestamp(modified_on/1000) as state_modified_on,
-        state,
+        INITCAP(state) AS state,
         case
             when to_timestamp(created_on/1000) >= '2019-01-01' then to_varchar(reason, 'utf-8')
             -- any records not matching condition are implicitly null


### PR DESCRIPTION
<!-- REQUIRED -->
<!-- The title of this PR must be prefixed with the Jira ticket -->
<!-- e.g., "[] My brief title" -->
# Problem
<!-- Describe the specific technical problem that this PR solves. -->

<!-- REQUIRED -->
Ticket: [SNOW-415](https://sagebionetworks.jira.com/browse/SNOW-415)

<!-- OPTIONAL -->
<!-- A brief description of the *technical* or *implementation* aspects of the problem -->
<!-- (Most or all contextual information about the problem should already be in Jira) -->

# Solution
<!-- Describe the specific technical solution that this PR provides -->

<!-- REQUIRED -->
<!-- For each of the acceptance criteria specified in the Jira ticket, describe how this criterion was addressed. -->
<!-- If you feel that it helps with clarity, provide links to specific lines within your changes. -->
## Acceptance Criteria
✅ Explore the DATA_ACCESS_SUBMISSION data in Snowflake: establish how the concrete type relates to the accessor changes.
  * In consultation with Samia, we decided not to rely upon the backend categorization of request vs. renewal. A data access submissions `submission_type` could be wholly determined by previous submissions associated with the same access request.

✅ Consider the practicality of differentiating between a renewal vs. update of an AR. Both should manifest as as Renewal objects from a backend perspective, but what is the value of making this distinction to an analyst? How clearly can we make this distinction to begin with?
  * ibid. 

<!-- OPTIONAL -->
<!-- Describe any additional changes made that aren't relevant to the acceptance criteria. -->
<!-- Provide additional information that could help reviewers understand these changes and any potential side effects. -->

## Implementation

I implement a `submission_type` column in the `int_synapse_data_access_submission_enriched` model, which I then propagate downstream to `data_access_submission_event` and `data_access_submission_dashboard` mart models.

The `submission_type` is one of:

* New
* Update
* Annual renewal

defined like so:

### New
* If this is the first submission associated with a request
* If there are no previously accepted submissions (i.e., all previous submissions were either REJECTED or CANCELLED)

### Update

* If this is a subsequent submission associated with a request and the most recent approved submission was approved less than 10 months from when this submission was created.
* Edge case to be cognizant of: If a requestor is trying to update their access request over the course of a few days, and their submissions are either rejected or cancelled before finally being approved, it’s possible that the first few submissions may be labeled “update” while latter submissions, including the approved submission, is labeled “renewal” despite these submissions all being part of the same access request action.

### Annual renewal

* If this is a subsequent submission associated with a request and the most recent approved submission was approved 10 or more months from when this submission was created.

<!-- LINKING TO CODE -->
<!-- See official documentation -->
<!-- https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet -->

# Testing
<!-- Describe any testing that was performed to validate the solution. -->

<!-- REQUIRED -->
<!-- Describe how changes were tested and provide *reproducible* and *self-contained* code blocks -->
<!-- That is, reviewers ought to be able to run the test code as-is in a new worksheet  -->
<!-- If changes cannot be tested (e.g., some account-level changes), briefly explain why this is the case -->
I deployed the updated synapse data warehouse models in my dev/clone database and spot checked submissions associated with an access request.

Here's an example which illustrates how we define `submission_type`:
```
select
  data_access_request_id,
  data_access_submission_id,
  state_modified_on,
  state,
  submission_type
from SYNAPSE_DATA_WAREHOUSE_DEV_SNOW_415_REQUEST_TYPE.RDS_RAW.INT_SYNAPSE_DATA_ACCESS_SUBMISSION_ENRICHED
where data_access_request_id = 1962
order by data_access_submission_id;
```

<!-- OPTIONAL -->
<!-- Link to automated tests -->
<!-- Provide additional information that could give reviewers further confidence in your solution --> 


[SNOW-415]: https://sagebionetworks.jira.com/browse/SNOW-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ