### PR TITLE
Add/update CLAUDE.md with tightly scoped information

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,57 @@
+<!-- Last reviewed: 2026-04 -->
+
+## Overview
+
+CI/CD workflows and shared actions for this repository.
+
+## Workflows
+
+### `ci.yaml` — main deployment pipeline
+
+Triggers on push to `dev` or `main`. Jobs run only on the branch where they are relevant:
+
+| Job | Trigger branch | What it does | Notable dependency |
+|-----|---------------|--------------|-------------------|
+| `schemachange_synapse_data_warehouse_dev` | `dev` | Deploys `synapse_data_warehouse/` to `SYNAPSE_DATA_WAREHOUSE_DEV` as `synapse_data_warehouse_dev_admin` | — |
+| `schemachange_synapse_data_warehouse_prod` | `main` | Deploys `synapse_data_warehouse/` to `SYNAPSE_DATA_WAREHOUSE` as `synapse_data_warehouse_admin` | — |
+| `schemachange_sage` | `main` | Deploys `sage/` to `SAGE` as `sage_admin` | — |
+| `schemachange_admin` | `main` | Runs all four `admin/` schemachange subdirs in order (warehouses → policies → ownership_grants → future_grants) | `needs: schemachange_synapse_data_warehouse_prod` |
+| `snowsql_admin` | `main` | Runs `admin/*.sql` files via `snow sql` (users, roles, databases, integrations, grants) | `needs: schemachange_admin` |
+
+The `schemachange_admin` → `snowsql_admin` dependency means all DDL migrations always precede the idempotent grant scripts.
+
+### `test_with_clone.yaml` — PR validation
+
+Triggers on pull requests targeting `dev`. Skipped if the `skip_cloning` label is present.
+
+1. Zero-copy clones `SYNAPSE_DATA_WAREHOUSE_DEV` → `SYNAPSE_DATA_WAREHOUSE_DEV_{branch}` (branch name sanitized to alphanumeric + underscores)
+2. Applies `synapse_data_warehouse/` schemachange migrations to the clone
+3. Tears down the clone when the PR is closed
+
+**Branch naming requirement:** Feature branches must start with `snow-` (e.g., `snow-407-feature`) for the `test_with_clone.yaml` workflow to trigger.
+
+**Python version:** `test_with_clone.yaml` uses Python 3.10; the `configure-snowflake-cli` action uses Python 3.11.
+
+## Shared actions
+
+### `actions/configure-snowflake-cli/`
+
+Sets up the Snowflake CLI (`snow`) with private key authentication. Accepts:
+- `PRIVATE_KEY_PASSPHRASE`
+- `PRIVATE_KEY`
+- `ACCOUNT`
+- `USER`
+
+Used by all jobs in both workflows.
+
+## Secrets and variables
+
+All credentials are stored as GitHub Actions secrets/vars under the `dev` and `prod` environments. Key names:
+
+- `SNOWSQL_ACCOUNT` — Snowflake account identifier
+- `ADMIN_SERVICE_USER` — service account username
+- `ADMIN_SERVICE_PRIVATE_KEY` / `ADMIN_SERVICE_PASS_PHRASE` — key pair auth
+- `SNOWFLAKE_SYNAPSE_DATA_WAREHOUSE_DATABASE` — database name (differs per environment)
+- `SNOWFLAKE_SYNAPSE_STAGE_STORAGE_INTEGRATION`, `SNOWFLAKE_SYNAPSE_STAGE_URL`
+- `SNOWFLAKE_SNAPSHOTS_STAGE_STORAGE_INTEGRATION`, `SNOWFLAKE_SNAPSHOTS_STAGE_URL`
+- `SAML2_ISSUER`, `SAML2_SSO_URL`, `SAML2_X509_CERT` — SAML integration secrets (prod only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,91 +2,55 @@
 
 ## Project
 
-Sage Bionetworks' Snowflake data warehouse: ingests Synapse platform data (MySQL RDS snapshots + S3 event data), transforms it via dbt, and serves analytics to Tableau, Streamlit dashboards, and ad-hoc SQL consumers. Multiple subsystems (schemachange DDL, dbt transforms, admin governance, Python ELT) each have their own subdirectory with dedicated CLAUDE.md files.
+Sage Bionetworks' Snowflake data warehouse. Ingests Synapse platform data (MySQL RDS snapshots + S3 event data), transforms it via dbt, and serves analytics to Tableau, Streamlit dashboards, and ad-hoc SQL consumers.
 
-## Stack
+## Subsystems
 
-- SQL: Snowflake dialect
-- Python: 3.10 (finance/Docker; GitHub Actions `test_with_clone`), 3.11 (GitHub Actions shared `configure-snowflake-cli` action)
-- schemachange: 4.0.1 (schema migration runner)
-- dbt: Snowflake adapter (profile name: `transform`)
-- SQLFluff: 3.0.6 — lints SQL with `--dialect snowflake --exclude-rules RF05,AM04,LT05,ST07`
-- Snowflake CLI (`snow`): latest, used for admin SQL execution
-- Pre-commit: SQLFluff hooks enforce SQL formatting automatically
+Each major subsystem is self-contained with its own `CLAUDE.md`:
 
-## Commands
+- `synapse_data_warehouse/` — schemachange-managed DDL for the primary Synapse databases (there are dev and prod deployements).
+- `transform/` — dbt project (staging → intermediate → marts)
+- `admin/` — account-level RBAC and objects, e.g.,  warehouse provisioning, masking policies, ownership transfers, and future grants.
+- `sage/` — schemachange-managed DDL for the `SAGE` analyst database (citations, governance, GA4 aggregates).
+- `finance/` — Python ELT pulling MIP financial data via API into Snowflake.
+- `analytics/` — ad-hoc SQL and one-off Python ETL scripts. Not deployed by CI.
+- `genie/` — GENIE cancer genomics queries and Snowpark scripts. Query-focused, minimal DDL.
+- `data_validation/` — Great Expectations checkpoints on raw + portal tables.
+- `.github/` — CI/CD workflows and shared actions.
 
-```bash
-# Admin SQL (executed by CI, role varies by script)
-snow sql -f admin/users.sql
-snow sql -f admin/roles.sql
-snow sql -f admin/databases.sql
-snow sql -f admin/grants.sql
+## Data flow
 
-# schemachange — synapse_data_warehouse (dev)
-schemachange \
-  --connection-name default \
-  --root-folder synapse_data_warehouse \
-  --config-folder synapse_data_warehouse \
-  --snowflake-role synapse_data_warehouse_dev_admin
-
-# schemachange — synapse_data_warehouse (prod)
-schemachange \
-  --connection-name default \
-  --root-folder synapse_data_warehouse \
-  --config-folder synapse_data_warehouse \
-  --snowflake-role synapse_data_warehouse_admin
-
-# schemachange — sage database
-schemachange \
-  --connection-name default \
-  --config-folder sage \
-  --snowflake-role sage_admin
-
-# schemachange — admin subsystems (each uses a different role)
-schemachange --connection-name default --root-folder admin/warehouses --snowflake-role SYSADMIN
-schemachange --connection-name default --root-folder admin/policies --snowflake-role ACCOUNTADMIN
-schemachange --connection-name default --root-folder admin/ownership_grants --snowflake-role SECURITYADMIN
-schemachange --connection-name default --root-folder admin/future_grants --snowflake-role SECURITYADMIN
-
-# dbt (see transform/CLAUDE.md for full details)
-dbt run --selector synapse_data_warehouse
-dbt run --selector sage                   # prod only
-dbt docs generate --target prod
-```
-
-## Data Models
-
-### Medallion architecture
+Two separate ingestion paths feed into `SYNAPSE_DATA_WAREHOUSE[_DEV]`:
 
 ```
-S3 (Parquet) + MySQL RDS snapshots
-    ↓ COPY INTO / external stages
-synapse_data_warehouse.SYNAPSE_RAW        ← schemachange-managed DDL
-synapse_data_warehouse.RDS_RAW            ← MySQL snapshot tables
-    ↓ dynamic tables / tasks
-synapse_data_warehouse.SYNAPSE_EVENT      ← file/node/object events
-synapse_data_warehouse.SYNAPSE_AGGREGATE  ← time-window user aggregates
-    ↓ dbt (staging → intermediate → marts)
-SYNAPSE_DATA_WAREHOUSE / SAGE             ← analyst-ready dynamic tables
-    ↓
-Tableau / Streamlit / ad-hoc SQL
+Glue pipeline                              MySQL RDS snapshots
+(event data + weekly snapshots)
+    ↓ Snowflake stages + tasks                 ↓ COPY INTO
+SYNAPSE_RAW                                RDS_LANDING → RDS_RAW
+    │                                              │
+    └──────────────────┬────────────────────────── ┘
+                       ↓ dynamic tables / tasks
+           SYNAPSE_EVENT      ← event data (file/node/object)
+           SYNAPSE            ← most-recent-state objects
+           SYNAPSE_AGGREGATE  ← time-window aggregates
+                       ↓ dbt (staging → intermediate → marts)
+           SYNAPSE_DATA_WAREHOUSE marts    ← analyst-ready dynamic tables
+           SAGE schemas                   ← analyst schemas; may draw from
+                                             SYNAPSE_DATA_WAREHOUSE or other sources
+                       ↓
+           Tableau / Streamlit / ad-hoc SQL
 ```
 
-### Database mapping
+## Database environments
 
 | Database | Environment | Managed by |
 |----------|-------------|------------|
 | `SYNAPSE_DATA_WAREHOUSE` | Prod | schemachange + dbt |
 | `SYNAPSE_DATA_WAREHOUSE_DEV` | Dev | schemachange + dbt |
 | `SYNAPSE_DATA_WAREHOUSE_DEV_{branch}` | PR clone | CI/CD zero-copy clone |
-| `SAGE` | Prod only | schemachange (sage/) |
+| `SAGE` | Prod only | schemachange (`sage/`) |
 
-### Key env vars (names only, values in secrets)
-
-`SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_PRIVATE_KEY_PATH`, `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`, `SNOWFLAKE_SYNAPSE_DATA_WAREHOUSE_DATABASE`, `SNOWFLAKE_SYNAPSE_STAGE_STORAGE_INTEGRATION`, `SNOWFLAKE_SYNAPSE_STAGE_URL`, `SNOWFLAKE_SNAPSHOTS_STAGE_STORAGE_INTEGRATION`, `SNOWFLAKE_SNAPSHOTS_STAGE_URL`, `STACK`
-
-## Conventions
+## Contributing conventions
 
 **Branch naming:** Feature branches must start with `snow-` (e.g., `snow-407-new-feature`) for the cloned-db test/deploy to succeed. Work off `dev`, not `main`.
 
@@ -94,56 +58,15 @@ Tableau / Streamlit / ad-hoc SQL
 
 **Skip clone label:** Add `skip_cloning` label to a PR to bypass the zero-copy clone test if no schema changes are involved.
 
-**Template variables in SQL:** Use `{{database_name}}`, `{{stage_storage_integration}}`, etc. (double curly braces). These are resolved by schemachange from environment variables. Add `--noqa: JJ01,PRS,TMP` on these lines to suppress the common SQLFluff template/jinja warnings.
+## Off-limits paths
 
-**SQLFluff noqa:** For lines with template variables or schema `USE` statements, use `--noqa: JJ01,PRS,TMP` by default. Add `CP01` or `CP02` only if that specific line also triggers capitalization rules.
-
-**Warehouse sizes:** Use `XSMALL` for most tasks; `MEDIUM` only for COPY INTO operations. All warehouses created with `initially_suspended = TRUE` and `auto_resume = TRUE`.
-
-**Timestamp conversion:** Source data timestamps are epoch milliseconds (NUMBER). Always divide by 1000 before passing to `TO_TIMESTAMP()`. Apply this conversion in the staging layer — never in intermediate or mart models.
-
-## Architecture
-
-Each major subsystem is self-contained:
-
-- `synapse_data_warehouse/` — schemachange-managed DDL for the primary warehouse. See `synapse_data_warehouse/CLAUDE.md`.
-- `transform/` — dbt project (staging → intermediate → marts). See `transform/CLAUDE.md`.
-- `admin/` — account-level RBAC, warehouses, policies. See `admin/CLAUDE.md`.
-- `sage/` — schemachange config for the SAGE cross-cutting database (citations, governance, GA4 aggregates). Mirrors synapse_data_warehouse patterns.
-- `finance/` — Python ELT pulling MIP financial data via API into Snowflake. Uses `snowflake-connector-python` 3.14.0 + `backoff` for retry logic.
-- `analytics/` — ad-hoc SQL and one-off Python ETL scripts. Not deployed by CI.
-- `genie/` — GENIE cancer genomics queries and Snowpark scripts. Query-focused, minimal DDL.
-- `data_validation/` — Great Expectations checkpoints on raw + portal tables.
-- `streamlit/` — Internal dashboards (data catalog, forecasting). Reads from SAGE/SYNAPSE_DATA_WAREHOUSE.
-
-## Constraints
-
-- **Never edit `private_keys/`** — contains Snowflake private key files used for authentication.
+- **Never edit `private_keys/`** — Snowflake private key files used for authentication.
 - **Never edit `.terraform/`** — generated Terraform provider binary. Terraform is a PoC; schemachange is the authoritative DDL tool.
 - **Never edit `data_validation/gx/uncommitted/`** — auto-generated GX docs and validation outputs.
-- **Ownership grants run separately from regular grants** — granting ownership on a TASK auto-suspends it, even when transferring to the same role. Ownership changes belong in `admin/ownership_grants/` (versioned, executed by SECURITYADMIN), not in `admin/grants.sql`.
-- **schemachange version numbers are immutable** — once a `V{version}__*.sql` script has been applied, it cannot be re-executed or renamed. Always increment the version.
 
-## Anti-Patterns — Do NOT
+## Related systems
 
-- **Do NOT mix ownership grants into `admin/grants.sql`** — ownership transfers have a side effect of auto-suspending tasks. They must live in `admin/ownership_grants/` and be executed separately (evidence: separate directory exists specifically for this, admin/README.md).
-- **Do NOT use repeatable (`R__`) scripts for tables that other objects depend on** — repeatable scripts re-run on every schemachange execution; if a dependent view/task exists, the re-creation can fail. Introduce tables in a `V__` script first (evidence: CONTRIBUTING.md explicit rule).
-- **Do NOT convert stable tables to dynamic tables without testing** — this was reverted once (`Revert 'convert file latest to dynamic table'`, commit `2a07475`). Test the lag behavior and ownership requirements before converting.
-- **Do NOT run `dbt run --selector sage` outside prod** — sage models are explicitly disabled for non-prod targets via `+enabled: "{{ target.name == 'prod' }}"`.
-- **Do NOT add new object types to a schema without setting up RBAC** — each new object type (table, view, task, stream, stage) needs: ownership grant to `{SCHEMA}_ALL_ADMIN`, a `{SCHEMA}_{TYPE}_READ` database role, future grants for both dev and prod databases. See `admin/README.md`.
-
-### Rolled-up subdirectories
-
-- `analytics/` — ad-hoc SQL and Python scripts, no deployment conventions beyond the branch/PR rules above.
-- `genie/` — Snowpark Python + SQL queries for GENIE cancer data; uses same Snowflake connection patterns as `finance/`.
-- `sage/` — schemachange config for SAGE database; same V/R script conventions as `synapse_data_warehouse/`.
-- `streamlit/` — Streamlit dashboards reading from prod databases; no write operations.
-- `finance/` — Python ELT for MIP financial data; runs in Docker (Python 3.10); uses OAuth + `backoff` retry for MIP API calls.
-- `data_validation/` — Great Expectations project; run `validation.py` to execute checkpoints against raw tables.
-
-## Related Systems
-
-- **Synapse platform** (Sage-Bionetworks/Synapse-Repository-Services): source of all RDS snapshots and S3 event data ingested here.
+- **Synapse platform** (Sage-Bionetworks/Synapse-Repository-Services): source of all RDS snapshots and S3 event data.
 - **Synapse portals** (NF, AD, HTAN): data loaded via `analytics/portal_elt.py` using `synapseclient`.
 - **MIP financial API**: source for `finance/` ELT pipeline.
 - **DataCite API**: source for `sage/citations/` DOI tracking.

--- a/admin/CLAUDE.md
+++ b/admin/CLAUDE.md
@@ -4,97 +4,94 @@
 
 Manages all Snowflake account-level configuration: user/role creation, warehouse provisioning, storage/SAML integrations, RBAC grants, masking policies, and ownership transfers. Changes here affect all databases and all users — treat this directory as infrastructure-as-code.
 
-## Commands
+## Deployment order (CI, push to `main` only)
 
-```bash
-# Executed by CI on push to main (different roles per script):
-snow sql -f admin/users.sql          # USERADMIN
-snow sql -f admin/roles.sql          # SYSADMIN
-snow sql -f admin/databases.sql      # SYSADMIN
-snow sql -f admin/integrations.sql \
-  --variable saml2_issuer="..." \
-  --variable saml2_sso_url="..." \
-  --variable saml2_x509_cert="..."   # ACCOUNTADMIN
+CI runs these steps in strict order via `schemachange_admin` → `snowsql_admin` job dependency:
 
-snow sql -f admin/grants.sql         # SECURITYADMIN
-snow sql -f admin/applications/grants.sql
+1. `schemachange admin/warehouses` — as `SYSADMIN`
+2. `schemachange admin/policies` — as `ACCOUNTADMIN`
+3. `schemachange admin/ownership_grants` — as `SECURITYADMIN`
+4. `schemachange admin/future_grants` — as `SECURITYADMIN`
+5. `snow sql -f admin/users.sql` — as `USERADMIN`
+6. `snow sql -f admin/roles.sql` — as `SYSADMIN`
+7. `snow sql -f admin/databases.sql` — as `SYSADMIN`
+8. `snow sql -f admin/integrations.sql` — as `ACCOUNTADMIN` (secrets passed as `--variable` flags)
+9. `snow sql -f admin/applications/grants.sql` — as `SECURITYADMIN`
+10. `snow sql -f admin/grants.sql` — as `SECURITYADMIN`
 
-# Versioned migrations (schemachange, run by CI):
-schemachange --connection-name default --root-folder admin/warehouses --snowflake-role SYSADMIN
-schemachange --connection-name default --root-folder admin/policies --snowflake-role ACCOUNTADMIN
-schemachange --connection-name default --root-folder admin/ownership_grants --snowflake-role SECURITYADMIN
-schemachange --connection-name default --root-folder admin/future_grants --snowflake-role SECURITYADMIN
-```
+The `snowsql_admin` job has `needs: schemachange_admin`, so schemachange steps always run before `snow sql` steps.
 
-## Architecture
+## Subdirectories
 
-### Three separate grant file types — never mix them
+| Directory | Contents | Deployed by | Role |
+|-----------|----------|-------------|------|
+| `admin/warehouses/` | Warehouse DDL | schemachange | SYSADMIN |
+| `admin/policies/` | Masking policy DDL | schemachange | ACCOUNTADMIN |
+| `admin/ownership_grants/` | `GRANT OWNERSHIP` transfers | schemachange | SECURITYADMIN |
+| `admin/future_grants/` | `GRANT ... ON FUTURE OBJECTS IN SCHEMA` | schemachange | SECURITYADMIN |
 
-| Location | What goes here | Executed by | Why separate |
-|----------|---------------|-------------|--------------|
-| `admin/grants.sql` | Account role grants, database usage, schema privileges, object SELECT/REFERENCES | SECURITYADMIN | Idempotent, re-runnable |
-| `admin/ownership_grants/V*.sql` | `GRANT OWNERSHIP ... REVOKE CURRENT GRANTS` | SECURITYADMIN | Side effect: auto-suspends tasks. Must run exactly once. |
-| `admin/future_grants/V*.sql` | `GRANT ... ON FUTURE OBJECTS IN SCHEMA` | SECURITYADMIN | Prevents privilege gaps on new objects; separate tracking |
+See each subdirectory's `CLAUDE.md` for specifics.
 
-### RBAC role hierarchy
+## Account-level role hierarchy
 
-Account-level roles (top to bottom):
 ```
 ACCOUNTADMIN
   └── SYSADMIN
         └── DATA_ENGINEER        ← developers/service accounts
-              └── (database roles via GRANT DATABASE ROLE)
   └── SECURITYADMIN
   └── USERADMIN
   └── MASKING_ADMIN
   └── TASKADMIN
 ```
 
-Per-database namespace pattern (database roles, not account roles):
+All custom account roles must be inherited by `SYSADMIN` (or a role already under it). This is required so that `SYSADMIN` can manage objects created by those roles.
+
+## RBAC for `SYNAPSE_DATA_WAREHOUSE` databases
+
+The `SYNAPSE_DATA_WAREHOUSE` and `SYNAPSE_DATA_WAREHOUSE_DEV` databases use a structured database-role-based access pattern. See the [Role and Privilege Management](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4076863503) and [Managing Object Privileges](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4115366084) Confluence pages for full details.
+
+**Summary:** Each schema is governed by a set of database roles scoped to that schema:
+
 ```
-{DATABASE}_PROXY_ADMIN            ← account role; owns the database roles below
-  └── {SCHEMA}_ALL_ADMIN          ← owns all objects in schema
+{DATABASE}_PROXY_ADMIN          ← account role; owns the cross-schema database roles below
+  └── {SCHEMA}_ALL_ADMIN        ← owns all objects in schema; granted OWNERSHIP on schema
         ├── {SCHEMA}_TABLE_READ
         ├── {SCHEMA}_VIEW_READ
         ├── {SCHEMA}_STAGE_READ
         ├── {SCHEMA}_TASK_READ
         ├── {SCHEMA}_STREAM_READ
-        └── {SCHEMA}_ALL_DEVELOPER  ← granted to DATA_ENGINEER account role
+        └── {SCHEMA}_ALL_DEVELOPER  ← inherited by DATA_ENGINEER account role
 ```
 
-Prod databases use `SYNAPSE_DATA_WAREHOUSE_PROXY_ADMIN`; dev uses `SYNAPSE_DATA_WAREHOUSE_DEV_PROXY_ADMIN`.
+- **Database roles** cannot be assumed directly by users; they must be inherited by account roles.
+- **Proxy admin** roles are account roles that own database roles and hold any account-level privileges needed (e.g., `EXECUTE MANAGED TASK`). This keeps functional and access-based role concerns separate.
+- **Only new object types** need role and privilege setup. Once future grants are in place, new objects of the same type are covered automatically.
 
-### Adding a new object type to a schema
+## RBAC for `SAGE` database
 
-When introducing a new object type (e.g., FUNCTION, STREAM) to an existing schema, you are responsible for the full RBAC setup:
+The `SAGE` database uses a simpler two-role model per schema. See the [Analyst Role Hierarchy and Privilege Management](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4315217948) Confluence page for full details.
 
-1. In `admin/grants.sql`: grant OWNERSHIP ON FUTURE `{TYPE}` to `{SCHEMA}_ALL_ADMIN`
-2. Create `{SCHEMA}_{TYPE}_READ` database role
-3. Grant type-specific privileges (e.g., USAGE for functions, SELECT for tables) to the read role
-4. Grant read role to `{SCHEMA}_ALL_DEVELOPER`
-5. Add `admin/future_grants/V{next}__schema_future_{type}.sql` for both prod and dev databases
-6. Add `admin/ownership_grants/V{next}__schema_ownership_{type}.sql` if transferring existing objects
+**Summary:** Each schema has two account roles (not database roles):
+- `{SCHEMA}_ADMIN` — write/ownership privileges; inherited by `SAGE_ADMIN`
+- `{SCHEMA}_ANALYST` — read-only privileges; inherited by `DATA_ANALYTICS`
+
+Analyst roles are owned by `USERADMIN`. Access requests and role inheritance changes must go through DPE.
 
 ## Conventions
 
-**Ownership transfer syntax:** Always use `REVOKE CURRENT GRANTS` when transferring ownership:
-```sql
-GRANT OWNERSHIP ON SCHEMA db.schema TO ROLE new_owner REVOKE CURRENT GRANTS;
-```
+**Versioned file naming:** `V{major}.{minor}.{patch}__{description}.sql`. The versioning sequence is shared across all schemachange-managed directories under `admin/` (i.e., `warehouses/`, `policies/`, `ownership_grants/`, `future_grants/` all share the same version number sequence, currently in the V1.x range).
 
-**Versioned file naming:** `V{major}.{minor}.{patch}__{description}.sql` — ownership_grants and future_grants maintain their own version sequences (starting at V1.x), separate from the synapse_data_warehouse V2.x sequence.
+**Ownership transfer syntax:** Always use `REVOKE CURRENT GRANTS`:
+```sql
+GRANT OWNERSHIP ON {{objects}} IN SCHEMA db.schema TO ROLE new_owner REVOKE CURRENT GRANTS;
+```
 
 **Service accounts:** `ADMIN_SERVICE` (ACCOUNTADMIN), `DEVELOPER_SERVICE` (DATA_ENGINEER), `DPE_SERVICE` (SYSADMIN + DATA_ENGINEER). Do not create new service accounts without updating `admin/users.sql`.
 
-**Warehouse standards:** All warehouses: `warehouse_type = STANDARD`, `initially_suspended = TRUE`, `auto_resume = TRUE`. Tableau warehouse uses `auto_suspend = 300` (longer for query cache warm-up); all others use 60–90 seconds.
+**Warehouse standards:** All warehouses: `warehouse_type = STANDARD`, `initially_suspended = TRUE`, `auto_resume = TRUE`, `auto_suspend = 60`. The Tableau warehouse uses `auto_suspend = 300` (longer for query cache warm-up).
 
 ## Constraints
 
-- **Ownership grants must run separately from `grants.sql`** — granting ownership on a TASK auto-suspends it, even when the owner doesn't change. Never add `GRANT OWNERSHIP` to `grants.sql`.
-- **`admin/policies/` requires ACCOUNTADMIN** — masking policy DDL requires account-admin privileges; do not attempt to run policy scripts as SYSADMIN.
+- **`admin/policies/` requires ACCOUNTADMIN** — masking policy DDL requires account-admin privileges.
 - **SAML integration variables are secrets** — `saml2_issuer`, `saml2_sso_url`, `saml2_x509_cert` are passed as `--variable` flags from GitHub secrets; never hardcode them.
 
-## Anti-Patterns — Do NOT
-
-- **Do NOT add `GRANT OWNERSHIP` statements to `admin/grants.sql`** — side effect auto-suspends tasks (evidence: `admin/ownership_grants/` directory exists specifically because this caused issues in the past).
-- **Do NOT skip creating future grants when adding a new schema or object type** — without future grants, new objects created in the schema will not be accessible to `DATA_ENGINEER` or read roles until manually re-granted.

--- a/admin/future_grants/CLAUDE.md
+++ b/admin/future_grants/CLAUDE.md
@@ -1,0 +1,35 @@
+<!-- Last reviewed: 2026-04 -->
+
+## Purpose
+
+Versioned schemachange scripts (`V{major}.{minor}.{patch}__{description}.sql`) that define future grants on schema-level objects. Executed by SECURITYADMIN.
+
+## Why future grants
+
+Without future grants, new objects created in a schema (e.g., a new table added by a `V__` migration) are not automatically accessible to `DATA_ENGINEER` or any read role. Future grants ensure privilege coverage persists as new objects are added.
+
+## When to add a script here
+
+Add a new versioned script here whenever:
+- A new schema is created (bootstrap all archetypes for every object type in that schema)
+- A new object type (e.g., FUNCTION) is introduced to an existing schema for the first time
+
+**Only new object types need grants set up.** Once future grants are in place for a given object type in a schema, new objects of that type are covered automatically.
+
+## Pattern
+
+Each script should cover both prod and dev databases:
+
+```sql
+-- Prod
+GRANT SELECT ON FUTURE TABLES IN SCHEMA SYNAPSE_DATA_WAREHOUSE.{schema}
+    TO DATABASE ROLE SYNAPSE_DATA_WAREHOUSE.{schema}_TABLE_READ; --noqa: JJ01,PRS,TMP
+
+-- Dev
+GRANT SELECT ON FUTURE TABLES IN SCHEMA SYNAPSE_DATA_WAREHOUSE_DEV.{schema}
+    TO DATABASE ROLE SYNAPSE_DATA_WAREHOUSE_DEV.{schema}_TABLE_READ; --noqa: JJ01,PRS,TMP
+```
+
+## Version numbering
+
+This directory shares the `V1.x` version sequence with `admin/ownership_grants/`, `admin/warehouses/`, and `admin/policies/`. Check the highest version number across all four directories before picking the next version.

--- a/admin/ownership_grants/CLAUDE.md
+++ b/admin/ownership_grants/CLAUDE.md
@@ -1,0 +1,23 @@
+<!-- Last reviewed: 2026-04 -->
+
+## Purpose
+
+Versioned schemachange scripts (`V{major}.{minor}.{patch}__{description}.sql`) that transfer ownership of Snowflake objects. Executed exactly once per script by SECURITYADMIN.
+
+## Why a separate directory
+
+Granting ownership on a TASK auto-suspends the task, even when transferring to the same role. These scripts must run only once and must never be mixed into `admin/grants.sql` (which is idempotent and re-run on every deploy).
+
+## Pattern
+
+```sql
+GRANT OWNERSHIP ON ALL {OBJECT_TYPE}S IN SCHEMA {database}.{schema}
+    TO ROLE {role}
+    REVOKE CURRENT GRANTS;
+```
+
+Always include `REVOKE CURRENT GRANTS`. Without it, executing the grant will fail if the role already owns the object.
+
+## Version numbering
+
+This directory shares the `V1.x` version sequence with `admin/future_grants/`, `admin/warehouses/`, and `admin/policies/`. Check the highest version number across all four directories before picking the next version.

--- a/sage/CLAUDE.md
+++ b/sage/CLAUDE.md
@@ -1,0 +1,51 @@
+<!-- Last reviewed: 2026-04 -->
+
+## Project
+
+schemachange-managed DDL for the `SAGE` analyst database. Contains schemas for domain-specific analytics: citations (DataCite DOI tracking), governance, and Google Analytics 4 aggregates. Deployed to prod only — there is no `SAGE_DEV` database.
+
+## Commands
+
+```bash
+# Prod deploy only (no dev environment for SAGE)
+schemachange \
+  --connection-name default \
+  --config-folder sage \
+  --snowflake-role sage_admin
+```
+
+## Schema layout
+
+| Schema | Contents | Managed by |
+|--------|----------|------------|
+| `CITATIONS` | DataCite DOI tracking | schemachange |
+| `GOOGLE_ANALYTICS_AGGREGATE` | GA4 event aggregates | schemachange |
+| `GOVERNANCE` | Governance-related objects | schemachange |
+| `AUDIT` | Audit objects | `sage_setup.sql` (SYSADMIN) |
+| `AD` | Alzheimer's Data portal objects | `sage_setup.sql` (SYSADMIN) |
+
+## RBAC
+
+The `SAGE` database uses a simplified two-role model per schema (not the database-role-based model used in `SYNAPSE_DATA_WAREHOUSE`). See the [Analyst Role Hierarchy and Privilege Management](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4315217948) Confluence page for full details.
+
+**Per-schema account roles:**
+- `{SCHEMA}_ADMIN` — write/ownership privileges; inherited by `SAGE_ADMIN`
+- `{SCHEMA}_ANALYST` — read-only privileges; inherited by `DATA_ANALYTICS`
+
+Privileges are assigned directly to these account roles (not via intermediate database roles). Role ownership is held by `USERADMIN`. Analysts who need role inheritance changes must request them through DPE.
+
+**`SAGE_ADMIN`** manages the entire `SAGE` database, analogous to `SYNAPSE_DATA_WAREHOUSE_ADMIN` for the data warehouse.
+
+## Script conventions
+
+Follows the same V/R versioning as `synapse_data_warehouse/`:
+
+- **Versioned (`V{major}.{minor}.{patch}__{description}.sql`):** one-time changes
+- **Repeatable (`R__{description}.sql`):** idempotent re-runs (e.g., `CREATE OR REPLACE`)
+
+The version sequence in `sage/` is independent of both `synapse_data_warehouse/` (V2.x) and `admin/` (V1.x). Check `SAGE.SCHEMACHANGE.CHANGE_HISTORY` before picking a new version number.
+
+## Constraints
+
+- **Prod only** — never attempt to deploy `sage/` to a dev or PR-clone database. There is no `SAGE_DEV`.
+- **Do NOT run `dbt run --selector sage` without `--target prod`** — sage dbt models are disabled for non-prod targets.

--- a/synapse_data_warehouse/CLAUDE.md
+++ b/synapse_data_warehouse/CLAUDE.md
@@ -2,13 +2,7 @@
 
 ## Project
 
-schemachange-managed DDL for the primary Synapse data warehouse. Contains all table definitions, dynamic tables, tasks, streams, and staged data ingestion for raw Synapse snapshots, RDS snapshots, and event aggregations. Version history tracked in `SYNAPSE_DATA_WAREHOUSE.SCHEMACHANGE.CHANGE_HISTORY`.
-
-## Stack
-
-- schemachange 4.0.1
-- Snowflake SQL (dialect)
-- Template variables resolved at deploy time from env vars
+schemachange-managed DDL for the primary Synapse data warehouse. Contains all table definitions, dynamic tables, tasks, streams, and staged data ingestion for raw Synapse snapshots, RDS snapshots, and event aggregations. Version history tracked in `<database>.SCHEMACHANGE.CHANGE_HISTORY`.
 
 ## Commands
 
@@ -27,13 +21,11 @@ schemachange \
   --config-folder synapse_data_warehouse \
   --snowflake-role synapse_data_warehouse_admin
 
-# Check what has been applied
--- SELECT * FROM SYNAPSE_DATA_WAREHOUSE.SCHEMACHANGE.CHANGE_HISTORY ORDER BY INSTALLED_ON DESC;
+# Check what has been applied (substitute the target database name)
+-- SELECT * FROM <database>.SCHEMACHANGE.CHANGE_HISTORY ORDER BY INSTALLED_ON DESC;
 ```
 
-## Data Models
-
-### Schema layout
+## Schema layout
 
 | Schema | Contents | Pattern |
 |--------|----------|---------|
@@ -46,7 +38,11 @@ schemachange \
 | `DATABASE_ROLES` | Role grant SQL (RBAC setup for this database) | V-scripts |
 | `SCHEMACHANGE` | Version history metadata — never edit manually | Auto-created |
 
-### Template variables
+## RBAC
+
+This database follows the structured database-role-based access pattern. See `admin/CLAUDE.md` for the full hierarchy and `admin/future_grants/CLAUDE.md` for adding new object types. The `database_roles/` subdirectory contains the V-scripts that set up database roles and grants for each schema.
+
+## Template variables
 
 Every SQL file uses `{{database_name}}` to stay environment-agnostic:
 
@@ -57,7 +53,7 @@ COPY INTO {{database_name}}.synapse_raw.my_table
   FROM @{{stage_storage_integration}}_STAGE/path/;
 ```
 
-Available variables (set via env vars in schemachange-config.yml):
+Available variables (set via env vars resolved from `schemachange-config.yml`):
 - `database_name` → `SYNAPSE_DATA_WAREHOUSE` or `SYNAPSE_DATA_WAREHOUSE_DEV`
 - `stage_storage_integration` → name of the Synapse S3 stage integration
 - `stage_url` → S3 URL for the Synapse stage
@@ -65,9 +61,9 @@ Available variables (set via env vars in schemachange-config.yml):
 - `snapshots_stage_url` → S3 URL for RDS snapshots
 - `stack` → environment identifier
 
-## Conventions
+**SQLFluff noqa:** Use `--noqa: JJ01,PRS,TMP` on lines with template variables. Add `CP01` or `CP02` only if that specific line also triggers capitalization rules.
 
-### Versioned vs. repeatable scripts
+## Versioned vs. repeatable scripts
 
 **Versioned (`V{major}.{minor}.{patch}__{description}.sql`):**
 - Use for: `CREATE TABLE`, `CREATE STREAM`, new objects that other objects depend on
@@ -77,9 +73,9 @@ Available variables (set via env vars in schemachange-config.yml):
 **Repeatable (`R__{description}.sql`):**
 - Use for: `CREATE OR ALTER TABLE`, `CREATE TASK IF NOT EXISTS` (idempotent re-runs)
 - Re-executed whenever the file content changes
-- Do NOT use for tables that are referenced by tasks, streams, or dynamic tables that won't be recreated — use a V-script instead
+- Do NOT use for tables referenced by tasks, streams, or dynamic tables that won't be recreated — use a V-script instead
 
-### Dynamic table pattern
+## Dynamic table pattern
 
 ```sql
 CREATE OR REPLACE DYNAMIC TABLE {{database_name}}.schema.table_name
@@ -89,8 +85,7 @@ CREATE OR REPLACE DYNAMIC TABLE {{database_name}}.schema.table_name
 AS
 SELECT
     col1,
-    col2,
-    ...
+    col2
 FROM {{database_name}}.source_schema.source_table
 QUALIFY ROW_NUMBER() OVER (
     PARTITION BY <grain_columns>
@@ -98,7 +93,9 @@ QUALIFY ROW_NUMBER() OVER (
 ) = 1;
 ```
 
-### Task pattern (repeatable scripts)
+Do NOT convert stable snapshot tables to dynamic tables without testing — dynamic table conversion was reverted once (`Revert 'convert file latest to dynamic table'`, commit `2a07475`) due to ownership and lag behavior issues. Validate in dev first.
+
+## Task pattern (repeatable scripts)
 
 ```sql
 CREATE TASK IF NOT EXISTS {{database_name}}.schema.task_name
@@ -115,7 +112,7 @@ ALTER TASK {{database_name}}.schema.task_name RESUME;
 - Use `user_task_managed_initial_warehouse_size` — avoids needing a separate warehouse.
 - CRON uses `America/Los_Angeles` timezone.
 
-### S3 COPY INTO pattern
+## S3 COPY INTO pattern
 
 ```sql
 COPY INTO {{database_name}}.synapse_raw.table_name
@@ -134,10 +131,6 @@ NULLIF(REGEXP_REPLACE(METADATA$FILENAME, '.*partition_key=([^/]+)/.*', '\\1'), '
 
 - **Never edit `SCHEMACHANGE.CHANGE_HISTORY` directly** — schemachange uses this to determine which scripts have been applied.
 - **Never reuse or edit an applied version number** — increment the minor or patch version instead.
-- **Do NOT use repeatable scripts to create tables with downstream dependencies** — if a task or dynamic table references a table, create that table in a V-script first, then reference it (evidence: explicit rule in CONTRIBUTING.md).
+- **Do NOT use repeatable scripts to create tables with downstream dependencies** — if a task or dynamic table references a table, create that table in a V-script first.
 - **Ownership transfers for this database belong in `admin/ownership_grants/`** — do not add `GRANT OWNERSHIP` here; it will auto-suspend tasks.
 
-## Anti-Patterns — Do NOT
-
-- **Do NOT convert stable snapshot tables to dynamic tables without testing** — dynamic table conversion was reverted once (`Revert 'convert file latest to dynamic table'`, commit `2a07475`) due to ownership and lag behavior issues. Validate in dev first.
-- **Do NOT omit the established `--noqa` pattern on template variable lines** — use the repo convention, generally `--noqa: JJ01,PRS,TMP` (and sometimes additional `CP01`/`CP02` as needed), because SQLFluff will error on `{{` syntax without the appropriate noqa comment.

--- a/transform/CLAUDE.md
+++ b/transform/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## Project
 
-dbt project that transforms raw Synapse RDS snapshot data into analyst-ready models deployed as Snowflake dynamic tables. Follows a strict staging → intermediate → marts layer hierarchy. Profile name: `transform`. Active work includes governance datamart expansion (SNOW-386).
+dbt project that transforms raw Synapse RDS snapshot data into analyst-ready models deployed as Snowflake dynamic tables. Profile name: `transform`. Source data lives in `SYNAPSE_DATA_WAREHOUSE.RDS_RAW`.
 
 ## Stack
 
 - dbt (Snowflake adapter), profile: `transform`
 - Snowflake dynamic tables (mart materialization)
-- Source data: `SYNAPSE_DATA_WAREHOUSE.RDS_RAW` (MySQL RDS snapshots)
+- SQLFluff: 3.0.6
 
 ## Commands
 
@@ -17,14 +17,13 @@ dbt project that transforms raw Synapse RDS snapshot data into analyst-ready mod
 dbt run --selector synapse_data_warehouse
 
 # Run sage models (prod only — skipped automatically in dev)
-dbt run --selector sage
+dbt run --selector sage --target prod
 
-# Run a specific model
+# Run a specific model(s)
 dbt run --select stg_synapse__access_approval
 dbt run --select intermediate.synapse
-dbt run --select marts.synapse_data_warehouse
 
-# Generate docs (requires prod target for full lineage)
+# Generate docs (prod target required for complete lineage)
 dbt docs generate --target prod
 
 # Test
@@ -33,91 +32,28 @@ dbt test
 
 **Profiles:** `~/.dbt/profiles.yml` must define a `transform` profile with `dev` and `prod` outputs. Create or update that file locally using the standard dbt profile format and Snowflake adapter settings; see the dbt profile configuration and Snowflake setup docs for the required structure and fields. Fill in credentials locally and do not commit them.
 
-## Data Models
+## Selectors
 
-### Layer hierarchy
+Defined in `selectors.yml`:
+- `synapse_data_warehouse` — staging + intermediate + `marts/synapse_data_warehouse/`; runs against dev and prod
+- `sage` — `marts/sage/` only; prod target required
+
+## Structure
 
 ```
-SOURCE: SYNAPSE_DATA_WAREHOUSE.RDS_RAW  (MySQL snapshots)
-    ↓
-STAGING  (stg_synapse__*)              materialized: view
-    - Standardize column names
-    - Convert epoch ms → TIMESTAMP_NTZ
-    - Rename id → {entity}_id
-    - Enforce primary key + not_null constraints
-    ↓
-INTERMEDIATE  (int_synapse_*)          materialized: view
-    - Join staging models into unified business entities
-    - Aggregate accessor changes into VARIANT columns
-    ↓
-MARTS  (descriptive names)             materialized: dynamic_table
-    - Target lag: 8 hours
-    - Warehouse: compute_xsmall
-    - synapse_data_warehouse/ → deployed to SYNAPSE_DATA_WAREHOUSE (dev + prod)
-    - sage/ → deployed to SAGE database (prod only)
+models/
+  staging/synapse/      ← stg_synapse__* views
+  intermediate/         ← int_synapse_* views
+  marts/
+    synapse_data_warehouse/  ← dynamic tables → SYNAPSE_DATA_WAREHOUSE
+    sage/                    ← dynamic tables → SAGE (prod only)
 ```
 
-### Naming conventions
-
-| Layer | Pattern | Example |
-|-------|---------|---------|
-| Staging | `stg_synapse__{entity}` | `stg_synapse__access_approval` |
-| Intermediate | `int_synapse_{entity}` | `int_synapse_acl` |
-| Marts | descriptive | `data_access_submission_event` |
-
-Note: staging uses double-underscore before source (`stg_synapse__`), single underscore in intermediate (`int_synapse_`).
-
-### Contract enforcement
-
-All models have `+contract: {enforced: true}` at the project root. Every model's YAML file must define:
-- `data_type` for every column
-- `constraints: [{type: not_null}]` on business key columns
-- `constraints: [{type: primary_key, columns: [...]}]` at the model level
-- `constraints: [{type: foreign_key, to: ref('upstream_model'), to_columns: [...], warn_unenforced: false}]` for cross-model references
-
-`warn_unenforced: false` is intentional — suppresses dbt warnings for Snowflake's unenforced FK constraints.
-
-### Timestamp conversion rule
-
-Source data timestamps are epoch **milliseconds** (NUMBER type). Convert in staging:
-```sql
-TO_TIMESTAMP(created_on_epoch / 1000) AS created_on  -- result: TIMESTAMP_NTZ
-```
-Never divide by 1000 in intermediate or mart models — it should already be a TIMESTAMP_NTZ by the time it leaves staging.
-
-### TIMESTAMP_NTZ(3)
-
-Use `TIMESTAMP_NTZ(3)` (millisecond precision) when source precision matters. Default `TIMESTAMP_NTZ` is fine for date-grain columns.
-
-### Accessor changes pattern
-
-`int_synapse_data_access_submission` aggregates access type changes into a single `VARIANT` column (`accessor_changes`) — a mapping of `principal_id (string) → access_type (GAIN_ACCESS | RENEW_ACCESS | REVOKE_ACCESS)`. Downstream mart models consume this as-is without further transformation.
-
-### Prod-only sage models
-
-Models in `marts/sage/` include `+enabled: "{{ target.name == 'prod' }}"`. They are silently skipped in dev and CI. To deploy sage models, run with `--target prod` and `--selector sage`.
-
-## Conventions
-
-**Selectors:** Use `selectors.yml` for environment-specific runs:
-- `synapse_data_warehouse` selector: staging + intermediate + `marts/synapse_data_warehouse/`
-- `sage` selector: `marts/sage/` only (prod target required)
-
-**Docs persistence:** `+persist_docs: {relation: true, columns: true}` is set at root. Every model and column must have a `description` in its YAML file.
-
-**Dynamic table config:** Mart models do not set `on_configuration_change` in SQL — it's inherited from `dbt_project.yml` (`apply`). Do not override it in individual model configs unless intentional.
-
-**Source YAML location:** `models/staging/synapse/_synapse__sources.yml` — all RDS_RAW source tables are defined here. Add new source tables here before referencing with `{{ source() }}`.
+See `models/CLAUDE.md` for model development conventions (naming, contracts, materialization, timestamp handling).
 
 ## Constraints
 
-- **Do not run `dbt run --selector sage` without `--target prod`** — sage models are disabled for non-prod targets; the run will succeed but produce no output, which is confusing.
-- **Do not add mart models to `marts/sage/` without the `enabled` condition** — they would deploy to dev databases and create objects in the wrong database.
-- **Do not skip contract definitions** — adding a column to a model SQL without adding it to the YAML will cause a contract violation error at runtime.
 - **`target/` and `logs/` are gitignored** — do not commit dbt artifacts.
+- **Do not run `dbt docs generate` without `--target prod`** — dev databases lack sage models; the generated lineage graph will be incomplete.
+- **Do not run `dbt run --selector sage` without `--target prod`** — sage models are disabled for non-prod targets; the run will succeed but produce no output.
 
-## Anti-Patterns — Do NOT
-
-- **Do NOT add new staging columns without updating the YAML contract** — dbt enforces column-level contracts; the run will fail if SQL and YAML diverge.
-- **Do NOT write timestamp conversions in intermediate or mart models** — epoch-to-timestamp conversion belongs in staging only. If a mart is receiving raw milliseconds, fix the staging model.
-- **Do NOT use `dbt docs generate` without `--target prod`** — dev databases lack sage models; the generated lineage graph will be incomplete (evidence: PR #303 added `--target prod` requirement after a doc generation failure).

--- a/transform/models/CLAUDE.md
+++ b/transform/models/CLAUDE.md
@@ -1,0 +1,68 @@
+<!-- Last reviewed: 2026-04 -->
+
+## Layer hierarchy
+
+```
+SOURCE: SYNAPSE_DATA_WAREHOUSE.RDS_RAW
+    ↓
+staging/synapse/   stg_synapse__*     materialized: view
+    ↓
+intermediate/      int_synapse_*      materialized: view
+    ↓
+marts/
+  synapse_data_warehouse/             materialized: dynamic_table → SYNAPSE_DATA_WAREHOUSE
+  sage/                               materialized: dynamic_table → SAGE (prod only)
+```
+
+## Naming conventions
+
+| Layer | Pattern | Example |
+|-------|---------|---------|
+| Staging | `stg_{source}__{entity}` | `stg_synapse__access_approval` |
+| Intermediate | `int_{source}_{entity}` | `int_synapse_acl` |
+| Marts | descriptive | `data_access_submission_event` |
+
+Staging uses double-underscore before source (`stg_synapse__`); intermediate uses single underscore (`int_synapse_`).
+
+## Staging layer responsibilities
+
+- Standardize column names (rename `id` → `{entity}_id`)
+- Convert epoch milliseconds → `TIMESTAMP_NTZ`: `TO_TIMESTAMP(col / 1000)`
+- Enforce primary key + not_null constraints via YAML contract
+
+Never perform epoch-to-timestamp conversion in intermediate or mart models — it belongs in staging only.
+
+Use `TIMESTAMP_NTZ(3)` when millisecond precision matters; plain `TIMESTAMP_NTZ` is fine for date-grain columns.
+
+## Intermediate layer responsibilities
+
+- Join staging models into unified business entities
+- Aggregate accessor changes into `VARIANT` columns
+
+`int_synapse_data_access_submission` stores `accessor_changes` as a `VARIANT` mapping of `principal_id (string) → access_type (GAIN_ACCESS | RENEW_ACCESS | REVOKE_ACCESS)`. Downstream mart models consume this as-is.
+
+## Mart materialization config
+
+Mart models configuration and materialization is configured in `dbt_project.yml` (do not override in individual models)
+
+## Prod-only sage models
+
+All models in `marts/sage/` include `+enabled: "{{ target.name == 'prod' }}"`. They are silently skipped in dev and CI. Do not add sage mart models without this condition.
+
+## Contract enforcement
+
+All models have `+contract: {enforced: true}` at the project root. Every model's YAML must define:
+- `data_type` for every column
+- `constraints: [{type: not_null}]` on business key columns
+- `constraints: [{type: primary_key, columns: [...]}]` at the model level
+- `constraints: [{type: foreign_key, to: ref('...'), to_columns: [...], warn_unenforced: false}]` for cross-model references
+
+`warn_unenforced: false` suppresses dbt warnings for Snowflake's unenforced FK constraints (intentional).
+
+Adding a column to model SQL without updating the YAML will cause a contract violation error at runtime.
+
+## Docs and sources
+
+**Docs persistence:** `+persist_docs: {relation: true, columns: true}` is set at root. Every model and column must have a `description` in its YAML file.
+
+**Source YAML:** `staging/synapse/_synapse__sources.yml` — all `RDS_RAW` source tables are defined here. Add new source tables here before referencing with `{{ source() }}`.


### PR DESCRIPTION
This is an updated version of @thomasyu888's original PR #306 . Generally speaking, it keeps information in high-level CLAUDE.md files _high-level_ and more tightly scopes specific information to its respective sub-directory.

### New files
- **`.github/CLAUDE.md`** — Documents the two CI/CD workflows (`ci.yaml` and `test_with_clone.yaml`), their job dependency ordering, trigger conditions, the shared `configure-snowflake-cli` action, and required secrets/variables.
- **`admin/future_grants/CLAUDE.md`** — Explains when to add future grant scripts, the SQL pattern (covering both prod and dev databases), and that the version sequence is shared across all four `admin/` schemachange subdirectories.
- **`admin/ownership_grants/CLAUDE.md`** — Explains why ownership grants are isolated (auto-suspend side effect on tasks), the `REVOKE CURRENT GRANTS` SQL pattern, and the shared version sequence.
- **`sage/CLAUDE.md`** — Covers the prod-only deploy command, schema layout, the simplified two-role RBAC model (`{SCHEMA}_ADMIN` / `{SCHEMA}_ANALYST`), and the independent version sequence.
- **`transform/models/CLAUDE.md`** — Contains all model development details: layer hierarchy, naming conventions, staging responsibilities (timestamp conversion, column renaming), mart materialization config, prod-only sage model guard, contract enforcement rules, and source/docs YAML conventions.

### Updated files
- **`CLAUDE.md`** (root) — Stripped to project overview, subsystem map, two-path data flow diagram, database environments, contributing conventions, and off-limits paths. All stack/command/convention details moved to subsystem CLAUDE.md files.
- **`admin/CLAUDE.md`** — Added explicit CI deployment order (10 steps with roles), split RBAC into separate `SYNAPSE_DATA_WAREHOUSE` (database-role model) and `SAGE` (two-role model) sections, and removed redundant anti-patterns.
- **`synapse_data_warehouse/CLAUDE.md`** — Fixed hard-coded prod DB reference to `<database>.SCHEMACHANGE.CHANGE_HISTORY`; moved RBAC details to point at `admin/CLAUDE.md`.
- **`transform/CLAUDE.md`** — Reduced to project overview, commands, selectors, and directory structure; model development details moved to `models/CLAUDE.md`.