### PR TITLE
[SNOW-467] Enable default secondary roles for analyst users

### DIFF
--- a/admin/users.sql
+++ b/admin/users.sql
@@ -253,26 +253,60 @@ BEGIN
 END;
 $$;
 
--- disable users
-ALTER USER DBT_SERVICE SET DISABLED = TRUE;
-ALTER USER AD_SERVICE SET DISABLED = TRUE;
+-- Disable users only when currently enabled.
+EXECUTE IMMEDIATE $$
+DECLARE
+    updated_users ARRAY DEFAULT ARRAY_CONSTRUCT();
+    username STRING;
+    disabled_value STRING;
+    is_disabled BOOLEAN;
+    user_cursor CURSOR FOR
+        SELECT "name", "disabled"
+        FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))
+        WHERE LOWER("name") IN (
+            'dbt_service',
+            'ad_service',
+            'thomasyu888',
+            'abby.vanderlinden@sagebase.org',
+            'anna.greenwood@sagebase.org',
+            'arti.singh@sagebase.org',
+            'brad.macdonald@sagebase.org',
+            'christina.conrad@sagebase.org',
+            'drew.duglan@sagebase.org',
+            'hayley.sanchez@sagebase.org',
+            'james.eddy@sagebase.org',
+            'kim.baggett@sagebase.org',
+            'lakaija.johnson@sagebase.org',
+            'lisa.pasquale@sagebase.org',
+            'natosha.edmonds@sagebase.org',
+            'nicholas.lee@sagebase.org',
+            'pranav.anbarasu@sagebase.org',
+            'richard.yaxley@sagebase.org',
+            'sarah.chan@sagebase.org',
+            'meghasyam@sagebase.org'
+        );
+BEGIN
+    SHOW USERS;
+    OPEN user_cursor;
+    LOOP
+        FETCH user_cursor INTO username, disabled_value;
+
+        IF (username IS NULL) THEN
+            BREAK;
+        END IF;
+
+        is_disabled := UPPER(COALESCE(disabled_value, 'FALSE')) = 'TRUE';
+
+        IF (NOT is_disabled) THEN
+            LET quoted_username STRING := '"' || :username || '"';
+            ALTER USER IDENTIFIER(:quoted_username) SET DISABLED = TRUE;
+            updated_users := ARRAY_APPEND(updated_users, username);
+        END IF;
+    END LOOP;
+    CLOSE user_cursor;
+    RETURN updated_users;
+END;
+$$;
+
 -- This user is owned by the Jumpcloud provisioner integration
 -- ALTER USER "JOE.SMITH@SAGEBASE.ORG" SET DISABLED = TRUE;
-ALTER USER THOMASYU888 SET DISABLED = TRUE;
-ALTER USER "abby.vanderlinden@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "anna.greenwood@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "arti.singh@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "brad.macdonald@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "christina.conrad@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "drew.duglan@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "hayley.sanchez@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "james.eddy@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "kim.baggett@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "lakaija.johnson@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "lisa.pasquale@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "natosha.edmonds@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "nicholas.lee@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "pranav.anbarasu@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "richard.yaxley@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "sarah.chan@sagebase.org" SET DISABLED = TRUE;
-ALTER USER "meghasyam@sagebase.org" SET DISABLED = TRUE;

--- a/admin/users.sql
+++ b/admin/users.sql
@@ -185,7 +185,11 @@ DECLARE
     user_cursor CURSOR FOR 
         SELECT "name", "type", "default_secondary_roles" 
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID())) 
-        WHERE "name" <> 'SNOWFLAKE'; -- A cursor over our users
+                WHERE "name" <> 'SNOWFLAKE'
+                        AND LOWER("name") NOT IN (
+                            'joe.smith@sagebase.org',
+                            'joni.harker@sagebase.org'
+                    ); -- Jumpcloud-managed users
     role_cursor CURSOR FOR
         SELECT "name"
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))

--- a/admin/users.sql
+++ b/admin/users.sql
@@ -185,11 +185,11 @@ DECLARE
     user_cursor CURSOR FOR 
         SELECT "name", "type", "default_secondary_roles" 
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID())) 
-                WHERE "name" <> 'SNOWFLAKE'
-                        AND LOWER("name") NOT IN (
-                            'joe.smith@sagebase.org',
-                            'joni.harker@sagebase.org'
-                    ); -- Jumpcloud-managed users
+        WHERE "name" <> 'SNOWFLAKE'
+            AND LOWER("name") NOT IN (
+                'joe.smith@sagebase.org',
+                'joni.harker@sagebase.org'
+            ); -- Jumpcloud-managed users
     role_cursor CURSOR FOR
         SELECT "name"
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))
@@ -214,31 +214,34 @@ BEGIN
             OR (POSITION('service' IN LOWER(username)) > 0);
         is_excluded_by_role := FALSE;
 
-        -- Inspect role grants for this user to detect developer/admin exclusions.
-        EXECUTE IMMEDIATE
-            'SHOW GRANTS TO USER IDENTIFIER(''' || :quoted_username || ''')';
-        OPEN role_cursor;
-        LOOP
-            -- Walk granted roles until we find an excluded role or exhaust results.
-            FETCH role_cursor INTO role_name;
+        IF (NOT is_service_user) THEN
+            -- Inspect role grants for this user to detect developer/admin exclusions.
+            EXECUTE IMMEDIATE
+                'SHOW GRANTS TO USER IDENTIFIER(''' || :quoted_username || ''')';
+            -- role_cursor must be opened immediately after each SHOW GRANTS call.
+            OPEN role_cursor;
+            LOOP
+                -- Walk granted roles until we find an excluded role or exhaust results.
+                FETCH role_cursor INTO role_name;
 
-            IF (role_name IS NULL) THEN
-                BREAK;
-            END IF;
+                IF (role_name IS NULL) THEN
+                    BREAK;
+                END IF;
 
-            IF (role_name IN ('DATA_ENGINEER', 'ACCOUNTADMIN', 'SYSADMIN', 'SECURITYADMIN', 'USERADMIN')) THEN
-                -- Any matching role disqualifies the user from analyst treatment.
-                is_excluded_by_role := TRUE;
-                BREAK;
-            END IF;
-        END LOOP;
-        CLOSE role_cursor;
+                IF (role_name IN ('DATA_ENGINEER', 'ACCOUNTADMIN', 'SYSADMIN', 'SECURITYADMIN', 'USERADMIN')) THEN
+                    -- Any matching role disqualifies the user from analyst treatment.
+                    is_excluded_by_role := TRUE;
+                    BREAK;
+                END IF;
+            END LOOP;
+            CLOSE role_cursor;
+        END IF;
 
         -- Only non-service users without excluded roles are treated as analysts.
         should_enable_all := (NOT is_service_user) AND (NOT is_excluded_by_role);
 
         IF (should_enable_all) THEN
-            IF (normalized_dsr_value NOT IN ('[\'ALL\']', '["ALL"]')) THEN
+            IF (normalized_dsr_value NOT IN ('[''ALL'']', '["ALL"]')) THEN
                 -- Enable automatic use of all granted secondary roles for analysts.
                 ALTER USER IDENTIFIER(:quoted_username) SET DEFAULT_SECONDARY_ROLES=('ALL');
                 updated_users := ARRAY_APPEND(updated_users, username);

--- a/admin/users.sql
+++ b/admin/users.sql
@@ -162,34 +162,91 @@ CREATE USER IF NOT EXISTS GENIE_SERVICE
 TYPE = SERVICE
 COMMENT = 'Service user to be used for launching Genie workflows in snowflake';
 
--- Set DEFAULT_SECONDARY_ROLES to [] (do not use secondary roles by default)
--- for all users
+-- Set DEFAULT_SECONDARY_ROLES based on user type and role access.
+-- A user is treated as an analyst if ALL of the following are true:
+--   1) user type is not SERVICE
+--   2) user name does not contain 'service' (case-insensitive)
+--   3) user is not granted any of these roles:
+--      DATA_ENGINEER, ACCOUNTADMIN, SYSADMIN, SECURITYADMIN, USERADMIN
+-- Analysts get DEFAULT_SECONDARY_ROLES=('ALL').
+-- Non-analysts (any user failing one or more checks above) get
+-- DEFAULT_SECONDARY_ROLES=().
 EXECUTE IMMEDIATE $$
 DECLARE
     updated_users ARRAY DEFAULT ARRAY_CONSTRUCT(); -- users we updated
     username STRING; -- a user identifier
-    dsr STRING; -- default secondary role setting
+    user_type STRING; -- user type from SHOW USERS
+    dsr_value STRING; -- default secondary role setting
+    normalized_dsr_value STRING; -- normalized default secondary role setting
+    role_name STRING; -- role granted to a user
+    is_service_user BOOLEAN; -- service users are excluded
+    is_excluded_by_role BOOLEAN; -- developers/admins are excluded
+    should_enable_all BOOLEAN; -- whether user should receive ['ALL']
     user_cursor CURSOR FOR 
-        SELECT "name", "default_secondary_roles" 
+        SELECT "name", "type", "default_secondary_roles" 
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID())) 
         WHERE "name" <> 'SNOWFLAKE'; -- A cursor over our users
+    role_cursor CURSOR FOR
+        SELECT "name"
+        FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))
+        WHERE "granted_on" = 'ROLE'; -- A cursor over roles granted to a user
 BEGIN
     SHOW USERS;
     OPEN user_cursor;
     LOOP
-        FETCH user_cursor INTO username, dsr;
+        -- Iterate through every user returned by SHOW USERS.
+        FETCH user_cursor INTO username, user_type, dsr_value;
 
         -- exit condition
         IF (username IS NULL) THEN
             BREAK;
         END IF;
 
-        -- loop condition
-        IF (dsr != '[]') THEN
-            LET quoted_username STRING := '"' || :username || '"';
-            ALTER USER IDENTIFIER(:quoted_username) SET DEFAULT_SECONDARY_ROLES=();
-            updated_users := ARRAY_APPEND(updated_users, username);
+        LET quoted_username STRING := '"' || :username || '"';
+        -- Normalize current value so comparisons work across formatting variants.
+        normalized_dsr_value := UPPER(COALESCE(dsr_value, ''));
+        -- Service users are excluded by explicit type and by service-like username.
+        is_service_user := (UPPER(COALESCE(user_type, '')) = 'SERVICE')
+            OR (POSITION('service' IN LOWER(username)) > 0);
+        is_excluded_by_role := FALSE;
+
+        -- Inspect role grants for this user to detect developer/admin exclusions.
+        EXECUTE IMMEDIATE
+            'SHOW GRANTS TO USER IDENTIFIER(''' || :quoted_username || ''')';
+        OPEN role_cursor;
+        LOOP
+            -- Walk granted roles until we find an excluded role or exhaust results.
+            FETCH role_cursor INTO role_name;
+
+            IF (role_name IS NULL) THEN
+                BREAK;
+            END IF;
+
+            IF (role_name IN ('DATA_ENGINEER', 'ACCOUNTADMIN', 'SYSADMIN', 'SECURITYADMIN', 'USERADMIN')) THEN
+                -- Any matching role disqualifies the user from analyst treatment.
+                is_excluded_by_role := TRUE;
+                BREAK;
+            END IF;
+        END LOOP;
+        CLOSE role_cursor;
+
+        -- Only non-service users without excluded roles are treated as analysts.
+        should_enable_all := (NOT is_service_user) AND (NOT is_excluded_by_role);
+
+        IF (should_enable_all) THEN
+            IF (normalized_dsr_value NOT IN ('[\'ALL\']', '["ALL"]')) THEN
+                -- Enable automatic use of all granted secondary roles for analysts.
+                ALTER USER IDENTIFIER(:quoted_username) SET DEFAULT_SECONDARY_ROLES=('ALL');
+                updated_users := ARRAY_APPEND(updated_users, username);
+            END IF;
+        ELSE
+            IF (normalized_dsr_value != '[]') THEN
+                -- Enforce no default secondary roles for excluded users.
+                ALTER USER IDENTIFIER(:quoted_username) SET DEFAULT_SECONDARY_ROLES=();
+                updated_users := ARRAY_APPEND(updated_users, username);
+            END IF;
         END IF;
+
     END LOOP;
     CLOSE user_cursor;
     RETURN updated_users;


### PR DESCRIPTION
<!-- REQUIRED -->
<!-- The title of this PR must be prefixed with the Jira ticket -->
<!-- e.g., "[] My brief title" -->
# Problem
<!-- Describe the specific technical problem that this PR solves. -->

<!-- REQUIRED -->
Ticket: [SNOW-467](https://sagebionetworks.jira.com/browse/SNOW-467)

<!-- OPTIONAL -->
<!-- A brief description of the *technical* or *implementation* aspects of the problem -->
<!-- (Most or all contextual information about the problem should already be in Jira) -->

# Solution
<!-- Describe the specific technical solution that this PR provides -->

<!-- REQUIRED -->
<!-- For each of the acceptance criteria specified in the Jira ticket, describe how this criterion was addressed. -->
<!-- If you feel that it helps with clarity, provide links to specific lines within your changes. -->
✅ update the DEFAULT_SECONDARY_ROLES setting to 'ALL' for each non-developer, non-service account user (i.e., each analyst user)
* I wrote a stored procedure which checks users against the analyst user criteria (described in the ticket) and updates the user's `DEFAULT_SECONDARY_ROLES` setting if it doesn't match what we expect. This would automatically capture new (non-)analyst users as well as "demote" analyst users to a disabled `DEFAULT_SECONDARY_ROLES` setting if they are granted roles which disqualify them from an analyst designation.

Additionally, I made some unrelated optimizations to how we disable users. Rather than running `ALTER USER` commands each time we deploy, I refactored these commands as a stored procedure which disables the user only if they are not already disabled.

<!-- OPTIONAL -->
<!-- Describe any additional changes made that aren't relevant to the acceptance criteria. -->
<!-- Provide additional information that could help reviewers understand these changes and any potential side effects. -->

<!-- LINKING TO CODE -->
<!-- See official documentation -->
<!-- https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet -->

# Testing
<!-- Describe any testing that was performed to validate the solution. -->
I tested the stored procedure by running it as a test script, verifying the results, and resetting the `DEFAULT_SECONDARY_ROLES` setting to the original values.

Test scripts:
[test_set_default_secondary_roles_by_analyst_rules.sql](https://gist.github.com/philerooski/54cfa864c359f85f8de4e81056c68754)
[test_reset_default_secondary_roles_all_users.sql](https://gist.github.com/philerooski/4f8372c996648822b172c59651cd0271)
[test_verify_default_secondary_roles_summary.sql](https://gist.github.com/philerooski/44fd8180d757afae53189b33b638b19f)

<!-- REQUIRED -->
<!-- Describe how changes were tested and provide *reproducible* and *self-contained* code blocks -->
<!-- That is, reviewers ought to be able to run the test code as-is in a new worksheet  -->
<!-- If changes cannot be tested (e.g., some account-level changes), briefly explain why this is the case -->

<!-- OPTIONAL -->
<!-- Link to automated tests -->
<!-- Provide additional information that could give reviewers further confidence in your solution --> 


[SNOW-467]: https://sagebionetworks.jira.com/browse/SNOW-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ