### PR TITLE
[SNOW-479] Bootstrap *HIGH PRIORITY* `RDS_LANDING` tables

### DIFF
--- a/synapse_data_warehouse/rds_landing/V2.71.0__create_parquet_file_format.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.0__create_parquet_file_format.sql
@@ -1,0 +1,4 @@
+USE SCHEMA {{database_name}}.RDS_LANDING; --noqa: JJ01,PRS,TMP
+
+CREATE OR REPLACE FILE FORMAT parquet_ff
+    TYPE = PARQUET;

--- a/synapse_data_warehouse/rds_landing/V2.71.0__create_parquet_file_format.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.0__create_parquet_file_format.sql
@@ -1,4 +1,0 @@
-USE SCHEMA {{database_name}}.RDS_LANDING; --noqa: JJ01,PRS,TMP
-
-CREATE OR REPLACE FILE FORMAT parquet_ff
-    TYPE = PARQUET;

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS data_access_notification (
     requirement_id     BIGINT  COMMENT 'The access requirement identifier',
     recipient_id       BIGINT  COMMENT 'User ID of the notification recipient',
     access_approval_id BIGINT  COMMENT 'The identifier of the associated access approval',
-    sent_on            BIGINT  COMMENT 'Epoch milliseconds when the notification was sent',
+    sent_on            TIMESTAMP_NTZ(9)  COMMENT 'Timestamp when the notification was sent',
     message_id         BIGINT  COMMENT 'Unique identifier of the message',
     etag               VARCHAR COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)'
 );

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -7,7 +7,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_APPROVAL/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -19,7 +19,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACL/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -31,7 +31,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACL_RESOURCE_ACCESS/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -43,7 +43,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACL_RESOURCE_ACCESS_TYPE/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -55,7 +55,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -67,7 +67,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION_ACCESSOR_CHANGE/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -79,7 +79,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION_STATUS/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -91,7 +91,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION_SUBMITTER/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -103,7 +103,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_REQUEST/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -115,7 +115,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_REQUIREMENT/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -127,7 +127,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_REQUIREMENT_PROJECT/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -139,7 +139,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_REQUIREMENT_REVISION/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -151,7 +151,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_NOTIFICATION/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );
@@ -163,7 +163,7 @@ USING TEMPLATE (
     FROM TABLE(
         INFER_SCHEMA(
             LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.PRINCIPAL_ALIAS/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
         )
     )
 );

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -1,7 +1,7 @@
 USE SCHEMA {{database_name}}.RDS_LANDING; --noqa: JJ01,PRS,TMP
 
 -- access_approval
-CREATE TABLE IF NOT EXISTS lan_synapse_access_approval (
+CREATE TABLE IF NOT EXISTS access_approval (
     id                  BIGINT    COMMENT 'Unique identifier for the access approval record',
     requirement_id      BIGINT    COMMENT 'Which requirement this approval satisfies',
     requirement_version BIGINT    COMMENT 'Version number of the access requirement at the time of approval',
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS lan_synapse_access_approval (
 );
 
 -- acl
-CREATE TABLE IF NOT EXISTS lan_synapse_acl (
+CREATE TABLE IF NOT EXISTS acl (
     id         BIGINT  COMMENT 'Unique identifier for the ACL (Access Control List)',
     owner_id   BIGINT  COMMENT 'ID of the entity or object that this ACL grants access to',
     owner_type VARCHAR COMMENT 'Type of entity or object that owns this ACL',
@@ -26,21 +26,21 @@ CREATE TABLE IF NOT EXISTS lan_synapse_acl (
 );
 
 -- acl_resource_access
-CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access (
+CREATE TABLE IF NOT EXISTS acl_resource_access (
     id       BIGINT COMMENT 'Unique identifier for this ACL resource access',
     owner_id BIGINT COMMENT 'The ACL identifier',
     group_id BIGINT COMMENT 'The user or team being granted access'
 );
 
 -- acl_resource_access_type
-CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access_type (
+CREATE TABLE IF NOT EXISTS acl_resource_access_type (
     id_oid     BIGINT  COMMENT 'The ACL resource access identifier',
     string_ele VARCHAR COMMENT 'The permission type (e.g., READ, UPDATE, DELETE, CHANGE_PERMISSIONS, DOWNLOAD, CREATE)',
     owner_id   BIGINT  COMMENT 'The ACL identifier'
 );
 
 -- data_access_submission
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission (
+CREATE TABLE IF NOT EXISTS data_access_submission (
     id                         BIGINT  COMMENT 'Unique identifier for the data access submission',
     access_requirement_id      BIGINT  COMMENT 'The access requirement identifier',
     data_access_request_id     BIGINT  COMMENT 'The data access request identifier',
@@ -53,14 +53,14 @@ CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission (
 );
 
 -- data_access_submission_accessor_changes
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_accessor_changes (
+CREATE TABLE IF NOT EXISTS data_access_submission_accessor_changes (
     submission_id BIGINT  COMMENT 'The data access submission identifier',
     accessor_id   BIGINT  COMMENT 'Identifier of the user whose access is being changed',
     access_type   VARCHAR COMMENT 'Type of access change. One of: GAIN_ACCESS, RENEW_ACCESS, REVOKE_ACCESS'
 );
 
 -- data_access_submission_status
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_status (
+CREATE TABLE IF NOT EXISTS data_access_submission_status (
     submission_id BIGINT  COMMENT 'The data access submission identifier',
     created_by    BIGINT  COMMENT 'Identifier of the user who created this status record',
     created_on    BIGINT  COMMENT 'Epoch milliseconds when the status was created',
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_status (
 );
 
 -- data_access_submission_submitter
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_submitter (
+CREATE TABLE IF NOT EXISTS data_access_submission_submitter (
     id                    BIGINT  COMMENT 'Unique identifier for this submitter record',
     access_requirement_id BIGINT  COMMENT 'The access requirement identifier',
     submitter_id          BIGINT  COMMENT 'User ID of the submitter',
@@ -80,7 +80,7 @@ CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_submitter (
 );
 
 -- data_access_request
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_request (
+CREATE TABLE IF NOT EXISTS data_access_request (
     id                    BIGINT  COMMENT 'Unique identifier for the data access request',
     access_requirement_id BIGINT  COMMENT 'Which access requirement this request is for',
     research_project_id   BIGINT  COMMENT 'The identifier of the research project which this data access request associates with',
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS lan_synapse_data_access_request (
 );
 
 -- access_requirement
-CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement (
+CREATE TABLE IF NOT EXISTS access_requirement (
     id                 BIGINT  COMMENT 'Unique identifier for the access requirement',
     name               VARCHAR COMMENT 'Unique human-readable name for the access requirement',
     concrete_type      VARCHAR COMMENT 'Fully qualified class name for the access requirement type',
@@ -106,13 +106,13 @@ CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement (
 );
 
 -- access_requirement_project
-CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_project (
+CREATE TABLE IF NOT EXISTS access_requirement_project (
     ar_id      BIGINT COMMENT 'The access requirement identifier',
     project_id BIGINT COMMENT 'The identifier of the project entity which this access requirement associates with'
 );
 
 -- access_requirement_revision
-CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_revision (
+CREATE TABLE IF NOT EXISTS access_requirement_revision (
     owner_id          BIGINT COMMENT 'The access requirement identifier',
     number            BIGINT COMMENT 'Revision number for this version of the access requirement. Revision numbers begin from 0.',
     modified_by       BIGINT COMMENT 'Identifier of the user who created this revision (i.e., modified the access requirement)',
@@ -121,7 +121,7 @@ CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_revision (
 );
 
 -- data_access_notification
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_notification (
+CREATE TABLE IF NOT EXISTS data_access_notification (
     id                 BIGINT  COMMENT 'Unique identifier for the notification record',
     notification_type  VARCHAR COMMENT 'Type of notification sent. One of: FIRST_RENEWAL_REMINDER, SECOND_RENEWAL_REMINDER, REVOCATION',
     requirement_id     BIGINT  COMMENT 'The access requirement identifier',
@@ -133,7 +133,7 @@ CREATE TABLE IF NOT EXISTS lan_synapse_data_access_notification (
 );
 
 -- principal_alias
-CREATE TABLE IF NOT EXISTS lan_synapse_principal_alias (
+CREATE TABLE IF NOT EXISTS principal_alias (
     id            BIGINT  COMMENT 'Unique identifier for the principal alias record',
     principal_id  BIGINT  COMMENT 'The globally unique identifier of the principal (user ID or team ID)',
     alias_unique  VARCHAR COMMENT 'Unique normalized alias value used for lookups. Guaranteed to be globally unique across all principals.',

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -128,7 +128,7 @@ CREATE TABLE IF NOT EXISTS data_access_notification (
     recipient_id       BIGINT  COMMENT 'User ID of the notification recipient',
     access_approval_id BIGINT  COMMENT 'The identifier of the associated access approval',
     sent_on            BIGINT  COMMENT 'Epoch milliseconds when the notification was sent',
-    message_id         VARCHAR COMMENT 'Unique identifier of the message',
+    message_id         BIGINT  COMMENT 'Unique identifier of the message',
     etag               VARCHAR COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)'
 );
 

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -57,11 +57,11 @@ BEGIN
         || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION/1/'', FILE_FORMAT => ''' || ff || ''''
         || ')))';
 
-    -- data_access_submission_accessor_change
+    -- data_access_submission_accessor_changes
     EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_accessor_change'
+        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_accessor_changes'
         || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION_ACCESSOR_CHANGE/1/'', FILE_FORMAT => ''' || ff || ''''
+        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION_ACCESSOR_CHANGES/1/'', FILE_FORMAT => ''' || ff || ''''
         || ')))';
 
     -- data_access_submission_status

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -1,123 +1,143 @@
 USE SCHEMA {{database_name}}.RDS_LANDING; --noqa: JJ01,PRS,TMP
 
-EXECUTE IMMEDIATE $$
-DECLARE
-    snapshot_folder STRING;
-    prefix_base STRING;
-    loc_pfx STRING;
-    ff STRING;
-BEGIN
-    -- Update snapshot_folder and prefix_base when a new snapshot is taken.
-    -- Adjust the ILIKE condition below to match your actual database name pattern.
-    IF (CURRENT_DATABASE() ILIKE '%dev%') THEN
-        snapshot_folder := 'dev-583-db-2026-04-01-2026-04-01';
-        prefix_base := 'dev583';
-    ELSE
-        snapshot_folder := 'prod-589-db-2026-05-20';
-        prefix_base := 'prod589';
-    END IF;
+-- access_approval
+CREATE TABLE IF NOT EXISTS lan_synapse_access_approval (
+    id                  BIGINT    COMMENT 'Unique identifier for the access approval record',
+    requirement_id      BIGINT    COMMENT 'Which requirement this approval satisfies',
+    requirement_version BIGINT    COMMENT 'Version number of the access requirement at the time of approval',
+    created_by          BIGINT    COMMENT 'Identifier of the user who created this access approval',
+    created_on          BIGINT    COMMENT 'Epoch milliseconds when the access approval was created',
+    modified_by         BIGINT    COMMENT 'Identifier of the user who last modified this access approval',
+    modified_on         BIGINT    COMMENT 'Epoch milliseconds when the access approval was last modified',
+    submitter_id        BIGINT    COMMENT 'User ID of the person who submitted the approval request',
+    accessor_id         BIGINT    COMMENT 'User ID of the person being granted access',
+    expired_on          BIGINT    COMMENT 'Epoch milliseconds when the approval expires. 0 means no expiration.',
+    state               VARCHAR   COMMENT 'State of the access approval. Valid values are APPROVED or REVOKED.',
+    etag                VARCHAR   COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)'
+);
 
-    loc_pfx := '@' || CURRENT_DATABASE()
-        || '.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/'
-        || snapshot_folder || '/' || prefix_base || '/' || prefix_base || '.';
-    ff := CURRENT_DATABASE() || '.RDS_LANDING.parquet_ff';
+-- acl
+CREATE TABLE IF NOT EXISTS lan_synapse_acl (
+    id         BIGINT  COMMENT 'Unique identifier for the ACL (Access Control List)',
+    owner_id   BIGINT  COMMENT 'ID of the entity or object that this ACL grants access to',
+    owner_type VARCHAR COMMENT 'Type of entity or object that owns this ACL',
+    created_on BIGINT  COMMENT 'Epoch milliseconds when the ACL was created',
+    etag       VARCHAR COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)'
+);
 
-    -- access_approval
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_access_approval'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'ACCESS_APPROVAL/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- acl_resource_access
+CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access (
+    id       BIGINT COMMENT 'Unique identifier for this ACL resource access',
+    owner_id BIGINT COMMENT 'The ACL identifier',
+    group_id BIGINT COMMENT 'The user or team being granted access'
+);
 
-    -- acl
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_acl'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'ACL/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- acl_resource_access_type
+CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access_type (
+    id_oid     BIGINT  COMMENT 'The ACL resource access identifier',
+    string_ele VARCHAR COMMENT 'The permission type (e.g., READ, UPDATE, DELETE, CHANGE_PERMISSIONS, DOWNLOAD, CREATE)',
+    owner_id   BIGINT  COMMENT 'The ACL identifier'
+);
 
-    -- acl_resource_access
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'ACL_RESOURCE_ACCESS/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- data_access_submission
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission (
+    id                         BIGINT  COMMENT 'Unique identifier for the data access submission',
+    access_requirement_id      BIGINT  COMMENT 'The access requirement identifier',
+    data_access_request_id     BIGINT  COMMENT 'The data access request identifier',
+    research_project_id        BIGINT  COMMENT 'The research project associated with this submission',
+    created_by                 BIGINT  COMMENT 'Identifier of the user who made this submission',
+    created_on                 BIGINT  COMMENT 'Epoch milliseconds when the submission was created',
+    access_requirement_version BIGINT  COMMENT 'Version of the access requirement at the time of submission',
+    etag                       VARCHAR COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)',
+    submission_serialized      BINARY  COMMENT 'Serialized representation of the complete submission object'
+);
 
-    -- acl_resource_access_type
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access_type'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'ACL_RESOURCE_ACCESS_TYPE/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- data_access_submission_accessor_changes
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_accessor_changes (
+    submission_id BIGINT  COMMENT 'The data access submission identifier',
+    accessor_id   BIGINT  COMMENT 'Identifier of the user whose access is being changed',
+    access_type   VARCHAR COMMENT 'Type of access change. One of: GAIN_ACCESS, RENEW_ACCESS, REVOKE_ACCESS'
+);
 
-    -- data_access_submission
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- data_access_submission_status
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_status (
+    submission_id BIGINT  COMMENT 'The data access submission identifier',
+    created_by    BIGINT  COMMENT 'Identifier of the user who created this status record',
+    created_on    BIGINT  COMMENT 'Epoch milliseconds when the status was created',
+    modified_by   BIGINT  COMMENT 'User ID of the person who last modified this status',
+    modified_on   BIGINT  COMMENT 'Epoch milliseconds when the submission status was last modified',
+    state         VARCHAR COMMENT 'Current state. One of: Submitted, Approved, Rejected, Cancelled',
+    reason        BINARY  COMMENT 'Binary blob containing the reason for the current state. Null for records before 2019 due to invalid UTF-8.'
+);
 
-    -- data_access_submission_accessor_changes
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_accessor_changes'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION_ACCESSOR_CHANGES/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- data_access_submission_submitter
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_submitter (
+    id                    BIGINT  COMMENT 'Unique identifier for this submitter record',
+    access_requirement_id BIGINT  COMMENT 'The access requirement identifier',
+    submitter_id          BIGINT  COMMENT 'User ID of the submitter',
+    current_submission_id BIGINT  COMMENT 'The current active data access submission',
+    etag                  VARCHAR COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)'
+);
 
-    -- data_access_submission_status
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_status'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION_STATUS/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- data_access_request
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_request (
+    id                    BIGINT  COMMENT 'Unique identifier for the data access request',
+    access_requirement_id BIGINT  COMMENT 'Which access requirement this request is for',
+    research_project_id   BIGINT  COMMENT 'The identifier of the research project which this data access request associates with',
+    created_by            BIGINT  COMMENT 'Identifier of the user who created this request',
+    created_on            BIGINT  COMMENT 'Epoch milliseconds when the request was created',
+    modified_by           BIGINT  COMMENT 'Identifier of the user who last modified this request',
+    modified_on           BIGINT  COMMENT 'Epoch milliseconds when the request was last modified',
+    etag                  VARCHAR COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)',
+    request_serialized    BINARY  COMMENT 'Serialized representation of the complete request object'
+);
 
-    -- data_access_submission_submitter
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_submitter'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION_SUBMITTER/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- access_requirement
+CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement (
+    id                 BIGINT  COMMENT 'Unique identifier for the access requirement',
+    name               VARCHAR COMMENT 'Unique human-readable name for the access requirement',
+    concrete_type      VARCHAR COMMENT 'Fully qualified class name for the access requirement type',
+    created_by         BIGINT  COMMENT 'Identifier of the user who created this access requirement',
+    created_on         BIGINT  COMMENT 'Epoch milliseconds when the access requirement was created',
+    current_rev_num    BIGINT  COMMENT 'Current revision number of this access requirement. Revision numbers begin from 0.',
+    is_two_fa_required BOOLEAN COMMENT 'Boolean flag indicating whether two-factor authentication is required for this access',
+    access_type        VARCHAR COMMENT 'Type of access controlled by this requirement',
+    etag               VARCHAR COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)'
+);
 
-    -- data_access_request
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_request'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_REQUEST/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- access_requirement_project
+CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_project (
+    ar_id      BIGINT COMMENT 'The access requirement identifier',
+    project_id BIGINT COMMENT 'The identifier of the project entity which this access requirement associates with'
+);
 
-    -- access_requirement
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'ACCESS_REQUIREMENT/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- access_requirement_revision
+CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_revision (
+    owner_id          BIGINT COMMENT 'The access requirement identifier',
+    number            BIGINT COMMENT 'Revision number for this version of the access requirement. Revision numbers begin from 0.',
+    modified_by       BIGINT COMMENT 'Identifier of the user who created this revision (i.e., modified the access requirement)',
+    modified_on       BIGINT COMMENT 'Epoch milliseconds when this revision was created',
+    serialized_entity BINARY COMMENT 'Serialized representation of the complete access requirement object at this revision'
+);
 
-    -- access_requirement_project
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_project'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'ACCESS_REQUIREMENT_PROJECT/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
+-- data_access_notification
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_notification (
+    id                 BIGINT  COMMENT 'Unique identifier for the notification record',
+    notification_type  VARCHAR COMMENT 'Type of notification sent. One of: FIRST_RENEWAL_REMINDER, SECOND_RENEWAL_REMINDER, REVOCATION',
+    requirement_id     BIGINT  COMMENT 'The access requirement identifier',
+    recipient_id       BIGINT  COMMENT 'User ID of the notification recipient',
+    access_approval_id BIGINT  COMMENT 'The identifier of the associated access approval',
+    sent_on            BIGINT  COMMENT 'Epoch milliseconds when the notification was sent',
+    message_id         VARCHAR COMMENT 'Unique identifier of the message',
+    etag               VARCHAR COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)'
+);
 
-    -- access_requirement_revision
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_revision'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'ACCESS_REQUIREMENT_REVISION/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
-
-    -- data_access_notification
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_notification'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_NOTIFICATION/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
-
-    -- principal_alias
-    EXECUTE IMMEDIATE
-        'CREATE TABLE IF NOT EXISTS lan_synapse_principal_alias'
-        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
-        || 'LOCATION => ''' || loc_pfx || 'PRINCIPAL_ALIAS/1/'', FILE_FORMAT => ''' || ff || ''''
-        || ')))';
-END;
-$$;
+-- principal_alias
+CREATE TABLE IF NOT EXISTS lan_synapse_principal_alias (
+    id            BIGINT  COMMENT 'Unique identifier for the principal alias record',
+    principal_id  BIGINT  COMMENT 'The globally unique identifier of the principal (user ID or team ID)',
+    alias_unique  VARCHAR COMMENT 'Unique normalized alias value used for lookups. Guaranteed to be globally unique across all principals.',
+    alias_display VARCHAR COMMENT 'Display version of the alias, preserving original character casing and formatting',
+    type          VARCHAR COMMENT 'Type of alias. One of: USER_NAME, TEAM_NAME, USER_EMAIL, USER_OPEN_ID, USER_ORCID',
+    etag          VARCHAR COMMENT 'Entity tag for optimistic concurrency control (36-character UUID)'
+);

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS acl (
 
 -- acl_resource_access
 CREATE TABLE IF NOT EXISTS acl_resource_access (
-    id       BIGINT COMMENT 'Unique identifier for this ACL resource access',
+    id       BIGINT COMMENT 'Unique identifier for this ACL resource access record',
     owner_id BIGINT COMMENT 'The ACL identifier',
     group_id BIGINT COMMENT 'The user or team being granted access'
 );

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -1,169 +1,121 @@
 USE SCHEMA {{database_name}}.RDS_LANDING; --noqa: JJ01,PRS,TMP
 
--- access_approval
-CREATE TABLE IF NOT EXISTS lan_synapse_access_approval
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_APPROVAL/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+DECLARE
+    snapshot_folder STRING;
+    prefix_base STRING;
+    loc_pfx STRING;
+    ff STRING;
+BEGIN
+    -- Update snapshot_folder and prefix_base when a new snapshot is taken.
+    -- Adjust the ILIKE condition below to match your actual database name pattern.
+    IF (CURRENT_DATABASE() ILIKE '%dev%') THEN
+        snapshot_folder := 'dev-583-db-2026-04-01-2026-04-01';
+        prefix_base := 'dev583';
+    ELSE
+        snapshot_folder := 'prod-589-db-2026-05-20';
+        prefix_base := 'prod589';
+    END IF;
 
--- acl
-CREATE TABLE IF NOT EXISTS lan_synapse_acl
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACL/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    loc_pfx := '@' || CURRENT_DATABASE()
+        || '.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/'
+        || snapshot_folder || '/' || prefix_base || '/' || prefix_base || '.';
+    ff := CURRENT_DATABASE() || '.RDS_LANDING.parquet_ff';
 
--- acl_resource_access
-CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACL_RESOURCE_ACCESS/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- access_approval
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_access_approval'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'ACCESS_APPROVAL/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- acl_resource_access_type
-CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access_type
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACL_RESOURCE_ACCESS_TYPE/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- acl
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_acl'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'ACL/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- data_access_submission
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- acl_resource_access
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'ACL_RESOURCE_ACCESS/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- data_access_submission_accessor_change
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_accessor_change
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION_ACCESSOR_CHANGE/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- acl_resource_access_type
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access_type'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'ACL_RESOURCE_ACCESS_TYPE/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- data_access_submission_status
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_status
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION_STATUS/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- data_access_submission
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- data_access_submission_submitter
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_submitter
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION_SUBMITTER/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- data_access_submission_accessor_change
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_accessor_change'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION_ACCESSOR_CHANGE/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- data_access_request
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_request
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_REQUEST/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- data_access_submission_status
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_status'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION_STATUS/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- access_requirement
-CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_REQUIREMENT/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- data_access_submission_submitter
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_submitter'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_SUBMISSION_SUBMITTER/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- access_requirement_project
-CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_project
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_REQUIREMENT_PROJECT/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- data_access_request
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_request'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_REQUEST/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- access_requirement_revision
-CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_revision
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_REQUIREMENT_REVISION/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- access_requirement
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'ACCESS_REQUIREMENT/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- data_access_notification
-CREATE TABLE IF NOT EXISTS lan_synapse_data_access_notification
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_NOTIFICATION/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- access_requirement_project
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_project'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'ACCESS_REQUIREMENT_PROJECT/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
 
--- principal_alias
-CREATE TABLE IF NOT EXISTS lan_synapse_principal_alias
-USING TEMPLATE (
-    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
-    FROM TABLE(
-        INFER_SCHEMA(
-            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.PRINCIPAL_ALIAS/1/',
-            FILE_FORMAT => '{{database_name}}.RDS_LANDING.parquet_ff'
-        )
-    )
-);
+    -- access_requirement_revision
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_revision'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'ACCESS_REQUIREMENT_REVISION/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
+
+    -- data_access_notification
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_data_access_notification'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'DATA_ACCESS_NOTIFICATION/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
+
+    -- principal_alias
+    EXECUTE IMMEDIATE
+        'CREATE TABLE IF NOT EXISTS lan_synapse_principal_alias'
+        || ' USING TEMPLATE (SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) FROM TABLE(INFER_SCHEMA('
+        || 'LOCATION => ''' || loc_pfx || 'PRINCIPAL_ALIAS/1/'', FILE_FORMAT => ''' || ff || ''''
+        || ')))';
+END;

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -1,5 +1,6 @@
 USE SCHEMA {{database_name}}.RDS_LANDING; --noqa: JJ01,PRS,TMP
 
+EXECUTE IMMEDIATE $$
 DECLARE
     snapshot_folder STRING;
     prefix_base STRING;
@@ -119,3 +120,4 @@ BEGIN
         || 'LOCATION => ''' || loc_pfx || 'PRINCIPAL_ALIAS/1/'', FILE_FORMAT => ''' || ff || ''''
         || ')))';
 END;
+$$;

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS access_approval (
     created_on          BIGINT    COMMENT 'Epoch milliseconds when the access approval was created',
     modified_by         BIGINT    COMMENT 'Identifier of the user who last modified this access approval',
     modified_on         BIGINT    COMMENT 'Epoch milliseconds when the access approval was last modified',
-    submitter_id        BIGINT    COMMENT 'User ID of the person who submitted the approval request',
+    submitter_id        BIGINT    COMMENT 'User ID of the person who created the data access request associated with this approval',
     accessor_id         BIGINT    COMMENT 'User ID of the person being granted access',
     expired_on          BIGINT    COMMENT 'Epoch milliseconds when the approval expires. 0 means no expiration.',
     state               VARCHAR   COMMENT 'State of the access approval. Valid values are APPROVED or REVOKED.',

--- a/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.1__create_high_priority_landing_tables.sql
@@ -1,0 +1,169 @@
+USE SCHEMA {{database_name}}.RDS_LANDING; --noqa: JJ01,PRS,TMP
+
+-- access_approval
+CREATE TABLE IF NOT EXISTS lan_synapse_access_approval
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_APPROVAL/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- acl
+CREATE TABLE IF NOT EXISTS lan_synapse_acl
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACL/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- acl_resource_access
+CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACL_RESOURCE_ACCESS/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- acl_resource_access_type
+CREATE TABLE IF NOT EXISTS lan_synapse_acl_resource_access_type
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACL_RESOURCE_ACCESS_TYPE/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- data_access_submission
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- data_access_submission_accessor_change
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_accessor_change
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION_ACCESSOR_CHANGE/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- data_access_submission_status
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_status
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION_STATUS/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- data_access_submission_submitter
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_submission_submitter
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_SUBMISSION_SUBMITTER/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- data_access_request
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_request
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_REQUEST/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- access_requirement
+CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_REQUIREMENT/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- access_requirement_project
+CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_project
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_REQUIREMENT_PROJECT/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- access_requirement_revision
+CREATE TABLE IF NOT EXISTS lan_synapse_access_requirement_revision
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.ACCESS_REQUIREMENT_REVISION/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- data_access_notification
+CREATE TABLE IF NOT EXISTS lan_synapse_data_access_notification
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.DATA_ACCESS_NOTIFICATION/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);
+
+-- principal_alias
+CREATE TABLE IF NOT EXISTS lan_synapse_principal_alias
+USING TEMPLATE (
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+    FROM TABLE(
+        INFER_SCHEMA(
+            LOCATION => '@{{database_name}}.RDS_LANDING.RDS_SNAPSHOTS_STAGE/rds-snapshot/prod-589-db-2026-05-19/prod589.PRINCIPAL_ALIAS/1/',
+            FILE_FORMAT => '{{database_name}}.RDS_LANDING.<file_format_name>'
+        )
+    )
+);


### PR DESCRIPTION
<!-- REQUIRED -->
<!-- The title of this PR must be prefixed with the Jira ticket -->
<!-- e.g., "[] My brief title" -->
# Problem
Ticket: https://sagebionetworks.jira.com/browse/SNOW-479

We move forward in the pipeline implementation plan by creating an initial set of `RDS_LANDING` tables. We prioritize the ones currently being used downstream in our INT models: https://github.com/Sage-Bionetworks/snowflake/pull/278 (+ `PRINCIPAL_ALIAS`). As such, the data types we are making tables for are:

- access_approval
- acl
- acl_resource_access
- acl_resource_access_type
- data_access_submission
- data_access_submission_accessor_change
- data_access_submission_status
- data_access_submission_submitter
- data_access_request
- access_requirement
- access_requirement_project
- access_requirement_revision
- data_access_notification
- principal_alias

---

# Solution

- [x] Introduce a `FILE FORMAT` object for parquet file types so we can infer the schemas of the S3 parquet files to build our tables (`V2.71.0__create_parquet_file_format.sql`)
- [x] Introduce the initial set of tables needed for our current INT models (`V2.71.1__create_high_priority_landing_tables.sql`)

**Context on `V2.71.1__create_high_priority_landing_tables.sql` complexity:**

**[SNOW-475](https://sagebionetworks.jira.com/browse/SNOW-475)** is blocked pending Platform's decision on the S3 path structure for dev/prod parquet objects.

**[SNOW-479](https://sagebionetworks.jira.com/browse/SNOW-479)** can still be done, but is impacted by 475 being blocked. The impact is it adds complexity and flimsiness to the schemas of the initial set of tables:

The `test_with_clone` job in this PR was initially failing because parquet file paths are inconsistent across DPE's RDS snapshots dev/prod buckets, meaning `{{database_name}}` isn't the only dynamic value in the `LOCATION` parameter of the `V2.71.1` script. I have to work around SNOW-475's blockage by making the entire path dynamic based on deployment environment. Two known limitations of the current approach:

1. I'm targeting a single specific stack to generate `LOCATION` values for both environments, rather than sampling across equivalent parquet files for a given data type.
2. Related, to that: The schema inference file is effectively hardcoded, so if `LOCATION` changes and this script gets rerun for whatever reason, it could break.

That said, I don't think these are worth blocking on. The goal right now is to get an initial set of tables in-place so we can build out the task graph and nail down the observability strategy. If tables come out malformed, that's a useful test of the observability layer anyway, and any path changes can be patched later.

---

# Testing
See the corresponding database clone of this feature branch on Snowsight.

[SNOW-475]: https://sagebionetworks.jira.com/browse/SNOW-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-479]: https://sagebionetworks.jira.com/browse/SNOW-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ