### PR TITLE
[hotfix] Modify idempotent statement

### DIFF
--- a/sage/ad/V1.4.7__ad_schema_init.sql
+++ b/sage/ad/V1.4.7__ad_schema_init.sql
@@ -1,3 +1,4 @@
 USE DATABASE {{ database_name }};
 
 -- SAGE.AD already exists in Snowflake; CREATE SCHEMA is intentionally omitted.
+SELECT 1; -- required to avoid schemachange "Empty SQL Statement" error

--- a/sage/nf/V1.4.3__nf_schema_init.sql
+++ b/sage/nf/V1.4.3__nf_schema_init.sql
@@ -1,3 +1,4 @@
 USE DATABASE {{ database_name }};
 
 -- NF schema already exists; no schema creation needed.
+SELECT 1; -- required to avoid schemachange "Empty SQL Statement" error


### PR DESCRIPTION
Because of the way schemachange parses its scripts, `USE DATABASE` by itself is not included in the script which it executes, resulting in a "Empty SQL Statement" error unless there is some other type of SQL statement.