### PR TITLE
[SNOW-460] Split pre-schemachange admin prerequisites (main-based)

### DIFF
--- a/sage/ad/V1.3.7__ad_schema_init.sql
+++ b/sage/ad/V1.3.7__ad_schema_init.sql
@@ -1,0 +1,3 @@
+USE DATABASE {{ database_name }};
+
+-- SAGE.AD already exists in Snowflake; CREATE SCHEMA is intentionally omitted.

--- a/sage/amp_als/V1.3.0__amp_als_schema_init.sql
+++ b/sage/amp_als/V1.3.0__amp_als_schema_init.sql
@@ -1,0 +1,4 @@
+USE DATABASE {{ database_name }};
+
+-- This schema is provisioned for AMP_ALS analyst-domain data.
+CREATE SCHEMA IF NOT EXISTS amp_als;

--- a/sage/ark/V1.3.1__ark_schema_init.sql
+++ b/sage/ark/V1.3.1__ark_schema_init.sql
@@ -1,0 +1,4 @@
+USE DATABASE {{ database_name }};
+
+-- This schema is provisioned for ARK analyst-domain data.
+CREATE SCHEMA IF NOT EXISTS ark;

--- a/sage/cckp/V1.3.5__cckp_schema_init.sql
+++ b/sage/cckp/V1.3.5__cckp_schema_init.sql
@@ -1,0 +1,4 @@
+USE DATABASE {{ database_name }};
+
+-- This schema is provisioned for CCKP analyst-domain data.
+CREATE SCHEMA IF NOT EXISTS cckp;

--- a/sage/elite/V1.3.6__elite_schema_init.sql
+++ b/sage/elite/V1.3.6__elite_schema_init.sql
@@ -1,0 +1,4 @@
+USE DATABASE {{ database_name }};
+
+-- This schema is provisioned for ELITE analyst-domain data.
+CREATE SCHEMA IF NOT EXISTS elite;

--- a/sage/genie/V1.3.2__genie_schema_init.sql
+++ b/sage/genie/V1.3.2__genie_schema_init.sql
@@ -1,0 +1,4 @@
+USE DATABASE {{ database_name }};
+
+-- This schema is provisioned for GENIE analyst-domain data.
+CREATE SCHEMA IF NOT EXISTS genie;

--- a/sage/nf/V1.3.3__nf_schema_init.sql
+++ b/sage/nf/V1.3.3__nf_schema_init.sql
@@ -1,0 +1,1 @@
+-- NF schema already exists; no schema creation needed.

--- a/sage/product/V1.3.4__product_schema_init.sql
+++ b/sage/product/V1.3.4__product_schema_init.sql
@@ -1,0 +1,4 @@
+USE DATABASE {{ database_name }};
+
+-- This schema is provisioned for PRODUCT analyst-domain data.
+CREATE SCHEMA IF NOT EXISTS product;


### PR DESCRIPTION
## Summary
Rebased follow-up branch onto `main` as requested.

This PR now contains the remaining schema init migrations:
- `sage/ad/V1.3.7__ad_schema_init.sql`
- `sage/amp_als/V1.3.0__amp_als_schema_init.sql`
- `sage/ark/V1.3.1__ark_schema_init.sql`
- `sage/cckp/V1.3.5__cckp_schema_init.sql`
- `sage/elite/V1.3.6__elite_schema_init.sql`
- `sage/genie/V1.3.2__genie_schema_init.sql`
- `sage/nf/V1.3.3__nf_schema_init.sql`
- `sage/product/V1.3.4__product_schema_init.sql`