### PR TITLE
[SNOW-473] Add finalizer task to RDS snapshots ingest task DAG

### DIFF
--- a/synapse_data_warehouse/rds_landing/V2.71.2__create_rds_snapshot_tasks.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.2__create_rds_snapshot_tasks.sql
@@ -4,7 +4,7 @@ USE SCHEMA {{database_name}}.RDS_LANDING; --noqa: JJ01,PRS,TMP
 -- Root task: refreshes stage metadata so COPY INTO tasks see
 -- the latest S3 files before any loading begins.
 -- ============================================================
-CREATE OR REPLACE TASK REFRESH_STAGE_TASK
+CREATE OR REPLACE TASK REFRESH_RDS_SNAPSHOTS_STAGE_TASK
     -- TEMPORARY: every minute for testing; revert before production rollout.
     SCHEDULE = 'USING CRON * * * * * America/Los_Angeles'
     USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE='SMALL'
@@ -20,7 +20,7 @@ CREATE OR REPLACE TASK REFRESH_STAGE_TASK
 CREATE OR REPLACE TASK PROXY_TASK_A
     WAREHOUSE = compute_xsmall
     COMMENT = 'No-op intermediary task. Snowflake limits a single node to 100 child tasks; this proxy fans out to all COPY INTO tasks. Add PROXY_TASK_B when child tasks on this node exceed 100.'
-    AFTER REFRESH_STAGE_TASK
+    AFTER REFRESH_RDS_SNAPSHOTS_STAGE_TASK
 AS
     SELECT 1;
 
@@ -261,4 +261,4 @@ ALTER TASK COPY_ACCESS_REQUIREMENT_REVISION_TASK RESUME;
 ALTER TASK COPY_DATA_ACCESS_NOTIFICATION_TASK RESUME;
 ALTER TASK COPY_PRINCIPAL_ALIAS_TASK RESUME;
 ALTER TASK PROXY_TASK_A RESUME;
-ALTER TASK REFRESH_STAGE_TASK RESUME;
+ALTER TASK REFRESH_RDS_SNAPSHOTS_STAGE_TASK RESUME;

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -5,7 +5,7 @@ alter task refresh_stage_task suspend;
 
 -- Create the finalizer task.
 create or replace task refresh_stage_finalizer_task
-    warehouse = 'COMPUTE_XSMALL'
+    user_task_managed_initial_warehouse_size = 'XSMALL'
     finalize = 'refresh_stage_task'
 as
 execute immediate $$
@@ -36,7 +36,7 @@ begin
     into :v_root_task_id, :v_graph_run_group_id, :v_root_task_state, :v_root_task_scheduled_time, :v_root_task_query_start_time, :v_root_task_completed_time
     from table(snowflake.information_schema.task_history())
     where upper(name) = 'REFRESH_STAGE_TASK'
-    and upper(database_name) = upper('{{database_name}}')
+    and upper(database_name) = upper('{{database_name}}') --noqa: JJ01,PRS,TMP
     qualify row_number() over (order by scheduled_time desc, query_start_time desc) = 1;
 
     -----------------------------------------------------------------------------------------------------------------------
@@ -58,7 +58,7 @@ begin
         select
             coalesce(count(distinct table_name), 0)
         into :v_loaded
-        from {{database_name}}.information_schema.load_history
+        from {{database_name}}.information_schema.load_history --noqa: JJ01,PRS,TMP
         where schema_name = 'RDS_LANDING'
         -- TODO: This filter makes sure we're only counting rows for tasks that loaded stuff after the root task was run,
         --       but it doesn't guarantee that the loads were all part of the same graph run. Find a way to set an upper

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -1,15 +1,17 @@
 use schema {{database_name}}.rds_landing; --noqa: JJ01,PRS,TMP
 
 -- Suspend root before modifying the graph.
-alter task {{database_name}}.rds_landing.refresh_stage_task suspend; --noqa: TMP
+alter task refresh_stage_task suspend; --noqa: TMP
 
 -- Create the finalizer task.
-create or replace task {{database_name}}.rds_landing.rds_snapshot_finalizer_task --noqa: TMP
+create or replace task rds_snapshot_finalizer_task --noqa: TMP
     warehouse = 'COMPUTE_XSMALL'
-    finalize = '{{database_name}}.rds_landing.refresh_stage_task' --noqa: TMP
+    finalize = 'refresh_stage_task' --noqa: TMP
 as
 declare
     v_graph_status  varchar;
+    v_root_task_id  varchar;
+    v_start_time    timestamp_ltz;
     v_loaded        integer default 0;
     v_failed        integer default 0;
     v_total_rows    integer default 0;
@@ -17,10 +19,27 @@ declare
     v_run_date      varchar;
     v_message       varchar;
 begin
-    let graph_json variant := parse_json(
-        system$get_task_graph_return_value('{{database_name}}.rds_landing.refresh_stage_task') --noqa: TMP
+    v_root_task_id := (
+        select system$task_runtime_info('CURRENT_ROOT_TASK_UUID')
     );
-    v_graph_status := graph_json:state::varchar;
+    v_start_time := (
+        select system$task_runtime_info('CURRENT_TASK_GRAPH_ORIGINAL_SCHEDULED_TIMESTAMP')::timestamp_ltz
+    );
+
+    select
+        case
+            when count_if(upper(state) like 'FAIL%') > 0 then 'failed'
+            when count_if(upper(state) like 'CANCEL%') > 0 then 'cancelled'
+            when count_if(upper(state) like 'SUCCEED%') > 0 then 'succeeded'
+            else 'unknown'
+        end
+    into :v_graph_status
+    from table(information_schema.task_history(
+        root_task_id => :v_root_task_id,
+        scheduled_time_range_start => :v_start_time,
+        scheduled_time_range_end => current_timestamp()
+    ));
+
     v_run_date     := to_varchar(current_date(), 'MM/DD/YYYY');
 
     if (v_graph_status != 'succeeded') then
@@ -58,7 +77,7 @@ begin
     return :v_message;
 end;
 
-alter task {{database_name}}.rds_landing.rds_snapshot_finalizer_task resume; --noqa: TMP
+alter task rds_snapshot_finalizer_task resume; --noqa: TMP
 
 -- Re-enable the full RDS snapshot task graph from the root.
-select system$task_dependents_enable('{{database_name}}.rds_landing.refresh_stage_task'); --noqa: JJ01,PRS,TMP
+select system$task_dependents_enable('refresh_stage_task'); --noqa: JJ01,PRS,TMP

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -1,0 +1,64 @@
+use schema {{database_name}}.rds_landing; --noqa: JJ01,PRS,TMP
+
+-- Suspend root before modifying the graph.
+alter task {{database_name}}.rds_landing.refresh_stage_task suspend; --noqa: TMP
+
+-- Create the finalizer task.
+create or replace task {{database_name}}.rds_landing.rds_snapshot_finalizer_task --noqa: TMP
+    warehouse = 'COMPUTE_XSMALL'
+    finalize = '{{database_name}}.rds_landing.refresh_stage_task' --noqa: TMP
+as
+declare
+    v_graph_status  varchar;
+    v_loaded        integer default 0;
+    v_failed        integer default 0;
+    v_total_rows    integer default 0;
+    v_failed_names  varchar default '';
+    v_run_date      varchar;
+    v_message       varchar;
+begin
+    let graph_json variant := parse_json(
+        system$get_task_graph_return_value('{{database_name}}.rds_landing.refresh_stage_task') --noqa: TMP
+    );
+    v_graph_status := graph_json:state::varchar;
+    v_run_date     := to_varchar(current_date(), 'MM/DD/YYYY');
+
+    if (v_graph_status != 'succeeded') then
+        v_message := '🔴 RDS snapshot ingestion FAILED — graph state: ' || v_graph_status
+            || ' · Run date: ' || v_run_date || ' — @team-dpe';
+    else
+        select
+            coalesce(sum(case when status = 'Loaded' then 1 else 0 end), 0),
+            coalesce(sum(case when status != 'Loaded' then 1 else 0 end), 0),
+            coalesce(sum(row_count), 0),
+            listagg(case when status != 'Loaded' then table_name end, ', ')
+                within group (order by table_name)
+        into :v_loaded, :v_failed, :v_total_rows, :v_failed_names
+        from information_schema.copy_history
+        where schema_name = 'RDS_LANDING'
+          and last_load_time >= dateadd('hour', -25, current_timestamp());
+
+        if (v_failed = 0) then
+            v_message := '✅ RDS snapshot ingestion complete — '
+                || v_loaded || '/157 record types loaded · '
+                || v_total_rows || ' rows total · Run date: ' || v_run_date;
+        else
+            v_message := '⚠️ RDS snapshot ingestion completed with errors — '
+                || v_loaded || '/157 loaded · '
+                || v_failed || ' failed: ' || v_failed_names
+                || ' · Run date: ' || v_run_date || ' — @team-dpe';
+        end if;
+    end if;
+
+    call system$send_snowflake_notification(
+        snowflake.notification.text_plain(:v_message),
+        snowflake.notification.integration('SLACK_INGEST_UPDATES')
+    );
+
+    return :v_message;
+end;
+
+alter task {{database_name}}.rds_landing.rds_snapshot_finalizer_task resume; --noqa: TMP
+
+-- Re-enable the full RDS snapshot task graph from the root.
+select system$task_dependents_enable('{{database_name}}.rds_landing.refresh_stage_task'); --noqa: JJ01,PRS,TMP

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -57,7 +57,7 @@ begin
     elseif (v_root_task_state = 'SUCCEEDED') then
         -- Get the count of loaded record types and total rows loaded.
         select
-            coalesce(count(*), 0),
+            coalesce(count(distinct table_name), 0),
             coalesce(sum(row_count), 0)
         into :v_loaded, :v_total_rows
         from {{database_name}}.information_schema.load_history
@@ -80,7 +80,7 @@ begin
         if (v_failed > 0) then
             -- Root task succeeded but some child tasks failed — partial success.
             v_message := '⚠️ RDS snapshot ingestion completed with errors — '
-                || '*' || v_loaded || '*' || '/157 loaded · '
+                || '*' || v_loaded || '*' || '/157 record types loaded · '
                 || '*' || v_failed || '*' || ' failed: ' || v_failed_names
                 || ' · *Graph Run Group ID*: ' || :v_graph_run_group_id
                 || ' · ' || '*' || v_total_rows || '*' || ' rows total'

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -1,13 +1,14 @@
 use schema {{database_name}}.rds_landing; --noqa: JJ01,PRS,TMP
 
 -- Suspend root before modifying the graph.
-alter task refresh_stage_task suspend; --noqa: TMP
+alter task refresh_stage_task suspend;
 
 -- Create the finalizer task.
 create or replace task rds_snapshot_finalizer_task --noqa: TMP
     warehouse = 'COMPUTE_XSMALL'
     finalize = 'refresh_stage_task' --noqa: TMP
 as
+$$
 declare
     v_graph_status  varchar;
     v_root_task_id  varchar;
@@ -76,8 +77,9 @@ begin
 
     return :v_message;
 end;
+$$;
 
-alter task rds_snapshot_finalizer_task resume; --noqa: TMP
+alter task rds_snapshot_finalizer_task resume;
 
 -- Re-enable the full RDS snapshot task graph from the root.
-select system$task_dependents_enable('refresh_stage_task'); --noqa: JJ01,PRS,TMP
+select system$task_dependents_enable('refresh_stage_task');

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -60,8 +60,7 @@ begin
             coalesce(count(*), 0),
             coalesce(sum(row_count), 0)
         into :v_loaded, :v_total_rows
-        from snowflake.account_usage.load_history
-        where catalog_name = '{{database_name}}'
+        from {{database_name}}.information_schema.load_history
         and schema_name = 'RDS_LANDING'
         -- TODO: This filter makes sure we're only counting rows for tasks that loaded stuff after the root task was run,
         --       but it doesn't guarantee that the loads were all part of the same graph run. Find a way to set an upper

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -8,7 +8,7 @@ create or replace task rds_snapshot_finalizer_task --noqa: TMP
     warehouse = 'COMPUTE_XSMALL'
     finalize = 'refresh_stage_task' --noqa: TMP
 as
-$$
+execute immediate $$
 declare
     v_graph_status  varchar;
     v_root_task_id  varchar;

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -22,19 +22,26 @@ declare
     v_message       varchar;
 begin
     v_root_task_id := (
-        select system$task_runtime_info('CURRENT_ROOT_TASK_UUID')
+                select root_task_id
+                from snowflake.account_usage.task_history
+                where upper(name) = upper('refresh_stage_task')
+                    and scheduled_time >= dateadd(hour, -25, current_timestamp())
+                qualify row_number() over (order by scheduled_time desc) = 1
     );
     v_start_time := (
-        select system$task_runtime_info('CURRENT_TASK_GRAPH_ORIGINAL_SCHEDULED_TIMESTAMP')::timestamp_ltz
+        select scheduled_time
+        from snowflake.account_usage.task_history
+        where upper(name) = upper('refresh_stage_task')
+        qualify row_number() over (order by scheduled_time desc) = 1
     );
 
-        select graph_run_group_id
-        into :v_graph_run_group_id
-        from snowflake.account_usage.task_history
-        where root_task_id = :v_root_task_id
-            and scheduled_time >= :v_start_time
-            and scheduled_time <= current_timestamp()
-        qualify row_number() over (order by scheduled_time desc) = 1;
+    select graph_run_group_id
+    into :v_graph_run_group_id
+    from snowflake.account_usage.task_history
+    where root_task_id = :v_root_task_id
+        and scheduled_time >= :v_start_time
+        and scheduled_time <= current_timestamp()
+    qualify row_number() over (order by scheduled_time desc) = 1;
 
     select
         case
@@ -45,10 +52,7 @@ begin
         end
     into :v_graph_status
     from snowflake.account_usage.task_history
-        where graph_run_group_id = :v_graph_run_group_id
-            and root_task_id = :v_root_task_id
-      and scheduled_time >= :v_start_time
-      and scheduled_time <= current_timestamp();
+    where graph_run_group_id = :v_graph_run_group_id;
 
     v_run_date     := to_varchar(current_date(), 'MM/DD/YYYY');
 
@@ -59,7 +63,7 @@ begin
         into :v_loaded, :v_total_rows
         from snowflake.account_usage.load_history
         where schema_name = 'RDS_LANDING'
-          and last_load_time >= dateadd('hour', -25, current_timestamp());
+          and last_load_time >= :v_start_time;
 
         select
             coalesce(count_if(upper(state) = 'FAILED'), 0),
@@ -68,9 +72,6 @@ begin
         into :v_failed, :v_failed_names
         from snowflake.account_usage.task_history
         where graph_run_group_id = :v_graph_run_group_id
-          and root_task_id = :v_root_task_id
-          and scheduled_time >= :v_start_time
-          and scheduled_time <= current_timestamp()
           and upper(name) != 'RDS_SNAPSHOT_FINALIZER_TASK';
 
         if (v_failed = 0) then

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -25,7 +25,7 @@ begin
 
     if (v_graph_status != 'succeeded') then
         v_message := '🔴 RDS snapshot ingestion FAILED — graph state: ' || v_graph_status
-            || ' · Run date: ' || v_run_date || ' — @team-dpe';
+            || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
     else
         select
             coalesce(sum(case when status = 'Loaded' then 1 else 0 end), 0),
@@ -46,7 +46,7 @@ begin
             v_message := '⚠️ RDS snapshot ingestion completed with errors — '
                 || v_loaded || '/157 loaded · '
                 || v_failed || ' failed: ' || v_failed_names
-                || ' · Run date: ' || v_run_date || ' — @team-dpe';
+                || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
         end if;
     end if;
 

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -97,6 +97,7 @@ begin
     else
         v_message := '⚠️ No graph status retrieved, or received an unexpected status. DPE team please view task statuses in '
             || 'snowflake.account_usage.task_history'
+            || ' · *Root Task State*: ' || coalesce(:v_root_task_state, 'NULL')
             || ' · *Run date*: ' || v_run_date || ' — @team-dpe';
     end if;
 

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -4,9 +4,9 @@ use schema {{database_name}}.rds_landing; --noqa: JJ01,PRS,TMP
 alter task refresh_stage_task suspend;
 
 -- Create the finalizer task.
-create or replace task rds_snapshot_finalizer_task --noqa: TMP
+create or replace task refresh_stage_finalizer_task
     warehouse = 'COMPUTE_XSMALL'
-    finalize = 'refresh_stage_task' --noqa: TMP
+    finalize = 'refresh_stage_task'
 as
 execute immediate $$
 declare
@@ -73,7 +73,7 @@ begin
         into :v_failed, :v_failed_names
         from table(snowflake.information_schema.task_history())
         where graph_run_group_id = :v_graph_run_group_id
-          and upper(name) != 'RDS_SNAPSHOT_FINALIZER_TASK';
+          and upper(name) != 'REFRESH_STAGE_FINALIZER_TASK';
 
         if (v_failed > 0) then
             -- Root task succeeded but some child tasks failed — partial success.
@@ -110,7 +110,7 @@ begin
 end;
 $$;
 
-alter task rds_snapshot_finalizer_task resume;
+alter task refresh_stage_finalizer_task resume;
 
 -- Re-enable the full RDS snapshot task graph from the root.
 select system$task_dependents_enable('refresh_stage_task');

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -48,12 +48,12 @@ begin
     if (v_root_task_state = 'FAILED') then
         -- Root task itself failed — graph could not run.
         v_message := '🔴 RDS snapshot ingestion FAILED — root task failed'
-            || ' · Root Task ID: ' || :v_root_task_id
-            || ' · Graph Run Group ID: ' || :v_graph_run_group_id
-            || ' · Scheduled Time: ' || to_varchar(:v_scheduled_time)
-            || ' · Query Start Time: ' || to_varchar(:v_query_start_time)
-            || ' · Completed Time: ' || to_varchar(:v_completed_time)
-            || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
+            || ' · *Root Task ID*: ' || :v_root_task_id
+            || ' · *Graph Run Group ID*: ' || :v_graph_run_group_id
+            || ' · *Scheduled Time*: ' || to_varchar(:v_scheduled_time)
+            || ' · *Query Start Time*: ' || to_varchar(:v_query_start_time)
+            || ' · *Completed Time*: ' || to_varchar(:v_completed_time)
+            || ' · *Run date*: ' || v_run_date || ' — @team-dpe';
     elseif (v_root_task_state = 'SUCCEEDED') then
         -- Get the count of loaded record types and total rows loaded.
         select
@@ -61,11 +61,12 @@ begin
             coalesce(sum(row_count), 0)
         into :v_loaded, :v_total_rows
         from snowflake.account_usage.load_history
-        where schema_name = 'RDS_LANDING'
-          -- TODO: This filter makes sure we're only counting rows for tasks that loaded stuff after the root task was run,
-          --       but it doesn't guarantee that the loads were all part of the same graph run. Find a way to set an upper
-          --       bound to ensure all loads are from the same graph run.
-          and last_load_time >= :v_scheduled_time;
+        where catalog_name = '{{database_name}}'
+        and schema_name = 'RDS_LANDING'
+        -- TODO: This filter makes sure we're only counting rows for tasks that loaded stuff after the root task was run,
+        --       but it doesn't guarantee that the loads were all part of the same graph run. Find a way to set an upper
+        --       bound to ensure all loads are from the same graph run.
+        and last_load_time >= :v_scheduled_time;
 
         -- Get the failed child tasks, if any.
         select
@@ -80,21 +81,21 @@ begin
         if (v_failed > 0) then
             -- Root task succeeded but some child tasks failed — partial success.
             v_message := '⚠️ RDS snapshot ingestion completed with errors — '
-                || v_loaded || '/157 loaded · '
-                || v_failed || ' failed: ' || v_failed_names
-                || ' · Graph Run Group ID: ' || :v_graph_run_group_id
-                || ' · ' || v_total_rows || ' rows total'
-                || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
+                || *v_loaded* || '/157 loaded · '
+                || *v_failed* || ' failed: ' || v_failed_names
+                || ' · *Graph Run Group ID*: ' || :v_graph_run_group_id
+                || ' · ' || *v_total_rows* || ' rows total'
+                || ' · *Run date*: ' || v_run_date || ' — @team-dpe';
         else
             -- Root task succeeded and all child tasks passed — full success.
             v_message := '✅ RDS snapshot ingestion complete — '
-                || v_loaded || '/157 record types loaded · '
-                || v_total_rows || ' rows total · Run date: ' || v_run_date;
+                || *v_loaded* || '/157 record types loaded · '
+                || *v_total_rows* || ' rows total · *Run date*: ' || v_run_date;
         end if;
     else
         v_message := '⚠️ No graph status retrieved. DPE team please view task statuses in '
             || 'snowflake.account_usage.task_history'
-            || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
+            || ' · *Run date*: ' || v_run_date || ' — @team-dpe';
     end if;
 
     call system$send_snowflake_notification(

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -81,16 +81,16 @@ begin
         if (v_failed > 0) then
             -- Root task succeeded but some child tasks failed — partial success.
             v_message := '⚠️ RDS snapshot ingestion completed with errors — '
-                || *v_loaded* || '/157 loaded · '
-                || *v_failed* || ' failed: ' || v_failed_names
+                || '*' || v_loaded || '*' || '/157 loaded · '
+                || '*' || v_failed || '*' || ' failed: ' || v_failed_names
                 || ' · *Graph Run Group ID*: ' || :v_graph_run_group_id
-                || ' · ' || *v_total_rows* || ' rows total'
+                || ' · ' || '*' || v_total_rows || '*' || ' rows total'
                 || ' · *Run date*: ' || v_run_date || ' — @team-dpe';
         else
             -- Root task succeeded and all child tasks passed — full success.
             v_message := '✅ RDS snapshot ingestion complete — '
-                || *v_loaded* || '/157 record types loaded · '
-                || *v_total_rows* || ' rows total · *Run date*: ' || v_run_date;
+                || '*' || v_loaded || '*' || '/157 record types loaded · '
+                || '*' || v_total_rows || '*' || ' rows total · *Run date*: ' || v_run_date;
         end if;
     else
         v_message := '⚠️ No graph status retrieved. DPE team please view task statuses in '

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -10,10 +10,12 @@ create or replace task rds_snapshot_finalizer_task --noqa: TMP
 as
 execute immediate $$
 declare
-    v_graph_status  varchar;
-    v_root_task_id  varchar;
+    v_root_task_id       varchar;
+    v_root_task_state    varchar;
     v_graph_run_group_id varchar;
-    v_start_time    timestamp_ltz;
+    v_scheduled_time     timestamp_ltz;
+    v_query_start_time   timestamp_ltz;
+    v_completed_time     timestamp_ltz;
     v_loaded        integer default 0;
     v_failed        integer default 0;
     v_total_rows    integer default 0;
@@ -21,50 +23,51 @@ declare
     v_run_date      varchar;
     v_message       varchar;
 begin
-    v_root_task_id := (
-                select root_task_id
-                from snowflake.account_usage.task_history
-                where upper(name) = upper('refresh_stage_task')
-                    and scheduled_time >= dateadd(hour, -25, current_timestamp())
-                qualify row_number() over (order by scheduled_time desc) = 1
-    );
-    v_start_time := (
-        select scheduled_time
-        from snowflake.account_usage.task_history
-        where upper(name) = upper('refresh_stage_task')
-        qualify row_number() over (order by scheduled_time desc) = 1
-    );
 
-    select graph_run_group_id
-    into :v_graph_run_group_id
-    from snowflake.account_usage.task_history
-    where root_task_id = :v_root_task_id
-        and scheduled_time >= :v_start_time
-        and scheduled_time <= current_timestamp()
-    qualify row_number() over (order by scheduled_time desc) = 1;
-
+    -----------------------------------------------------------------------------------------------------------------------
+    -- Step 1) Get the latest run of the root task for the graph, and other useful metadata on the graph run such as status.
+    -----------------------------------------------------------------------------------------------------------------------
     select
-        case
-                        when count_if(upper(state) = 'FAILED') > 0 then 'failed'
-                        when count_if(upper(state) = 'CANCELED') > 0 then 'cancelled'
-                        when count_if(upper(state) = 'SUCCEEDED') > 0 then 'succeeded'
-            else 'unknown'
-        end
-    into :v_graph_status
+        root_task_id,
+        graph_run_group_id,
+        state,
+        scheduled_time,
+        query_start_time,
+        completed_time
+    into :v_root_task_id, :v_graph_run_group_id, :v_root_task_state, :v_scheduled_time, :v_query_start_time, :v_completed_time
     from snowflake.account_usage.task_history
-    where graph_run_group_id = :v_graph_run_group_id;
+    where upper(name) = 'REFRESH_STAGE_TASK'
+    and upper(database_name) = upper('{{database_name}}')
+    qualify row_number() over (order by scheduled_time desc, query_start_time desc) = 1;
 
-    v_run_date     := to_varchar(current_date(), 'MM/DD/YYYY');
+    -----------------------------------------------------------------------------------------------------------------------
+    -- Step 2) Build and send a Slack notification based on root task state and graph state.
+    -----------------------------------------------------------------------------------------------------------------------
+    v_run_date := to_varchar(current_date(), 'MM/DD/YYYY');
 
-    if (v_graph_status = 'succeeded') then
+    if (v_root_task_state = 'FAILED') then
+        -- Root task itself failed — graph could not run.
+        v_message := '🔴 RDS snapshot ingestion FAILED — root task failed'
+            || ' · Root Task ID: ' || :v_root_task_id
+            || ' · Graph Run Group ID: ' || :v_graph_run_group_id
+            || ' · Scheduled Time: ' || to_varchar(:v_scheduled_time)
+            || ' · Query Start Time: ' || to_varchar(:v_query_start_time)
+            || ' · Completed Time: ' || to_varchar(:v_completed_time)
+            || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
+    elseif (v_root_task_state = 'SUCCEEDED') then
+        -- Get the count of loaded record types and total rows loaded.
         select
             coalesce(count(*), 0),
             coalesce(sum(row_count), 0)
         into :v_loaded, :v_total_rows
         from snowflake.account_usage.load_history
         where schema_name = 'RDS_LANDING'
-          and last_load_time >= :v_start_time;
+          -- TODO: This filter makes sure we're only counting rows for tasks that loaded stuff after the root task was run,
+          --       but it doesn't guarantee that the loads were all part of the same graph run. Find a way to set an upper
+          --       bound to ensure all loads are from the same graph run.
+          and last_load_time >= :v_scheduled_time;
 
+        -- Get the failed child tasks, if any.
         select
             coalesce(count_if(upper(state) = 'FAILED'), 0),
             listagg(case when upper(state) = 'FAILED' then name end, ', ')
@@ -74,19 +77,20 @@ begin
         where graph_run_group_id = :v_graph_run_group_id
           and upper(name) != 'RDS_SNAPSHOT_FINALIZER_TASK';
 
-        if (v_failed = 0) then
-            v_message := '✅ RDS snapshot ingestion complete — '
-                || v_loaded || '/157 record types loaded · '
-                || v_total_rows || ' rows total · Run date: ' || v_run_date;
-        else
+        if (v_failed > 0) then
+            -- Root task succeeded but some child tasks failed — partial success.
             v_message := '⚠️ RDS snapshot ingestion completed with errors — '
                 || v_loaded || '/157 loaded · '
                 || v_failed || ' failed: ' || v_failed_names
-                || ' - Run date: ' || v_run_date || ' — [TODO: tag team]';
+                || ' · Graph Run Group ID: ' || :v_graph_run_group_id
+                || ' · ' || v_total_rows || ' rows total'
+                || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
+        else
+            -- Root task succeeded and all child tasks passed — full success.
+            v_message := '✅ RDS snapshot ingestion complete — '
+                || v_loaded || '/157 record types loaded · '
+                || v_total_rows || ' rows total · Run date: ' || v_run_date;
         end if;
-    elseif (v_graph_status = 'failed') then
-        v_message := '🔴 RDS snapshot ingestion FAILED — graph state: ' || v_graph_status
-            || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
     else
         v_message := '⚠️ No graph status retrieved. DPE team please view task statuses in '
             || 'snowflake.account_usage.task_history'

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -46,7 +46,7 @@ begin
             v_message := '⚠️ RDS snapshot ingestion completed with errors — '
                 || v_loaded || '/157 loaded · '
                 || v_failed || ' failed: ' || v_failed_names
-                || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
+                || ' - Run date: ' || v_run_date || ' — [TODO: tag team]';
         end if;
     end if;
 

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -35,7 +35,7 @@ begin
         query_start_time,
         completed_time
     into :v_root_task_id, :v_graph_run_group_id, :v_root_task_state, :v_root_task_scheduled_time, :v_root_task_query_start_time, :v_root_task_completed_time
-    from snowflake.account_usage.task_history
+    from table(snowflake.information_schema.task_history())
     where upper(name) = 'REFRESH_STAGE_TASK'
     and upper(database_name) = upper('{{database_name}}')
     qualify row_number() over (order by scheduled_time desc, query_start_time desc) = 1;
@@ -74,7 +74,7 @@ begin
             listagg(case when upper(state) = 'FAILED' then name end, ', ')
                 within group (order by name)
         into :v_failed, :v_failed_names
-        from snowflake.account_usage.task_history
+        from table(snowflake.information_schema.task_history())
         where graph_run_group_id = :v_graph_run_group_id
           and upper(name) != 'RDS_SNAPSHOT_FINALIZER_TASK';
 

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -44,9 +44,9 @@ begin
     -----------------------------------------------------------------------------------------------------------------------
     v_run_date := to_varchar(current_date(), 'MM/DD/YYYY');
 
-    if (v_root_task_state = 'FAILED') then
-        -- Root task itself failed — graph could not run.
-        v_message := '🔴 RDS snapshot ingestion FAILED — root task failed'
+    if (v_root_task_state in ('FAILED', 'FAILED_AND_AUTO_SUSPENDED', 'CANCELLED')) then
+        -- Root task itself failed or was cancelled — graph could not run.
+        v_message := '🔴 RDS snapshot ingestion FAILED — root task failed or was cancelled'
             || ' · *Root Task ID*: ' || :v_root_task_id
             || ' · *Graph Run Group ID*: ' || :v_graph_run_group_id
             || ' · *Root Task Scheduled Time*: ' || to_varchar(:v_root_task_scheduled_time)
@@ -95,7 +95,7 @@ begin
                 || ' · *Run date*: ' || v_run_date;
         end if;
     else
-        v_message := '⚠️ No graph status retrieved. DPE team please view task statuses in '
+        v_message := '⚠️ No graph status retrieved, or received an unexpected status. DPE team please view task statuses in '
             || 'snowflake.account_usage.task_history'
             || ' · *Run date*: ' || v_run_date || ' — @team-dpe';
     end if;

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -18,7 +18,6 @@ declare
     v_root_task_completed_time   timestamp_ltz;
     v_loaded        integer default 0;
     v_failed        integer default 0;
-    v_total_rows    integer default 0;
     v_failed_names  varchar default '';
     v_run_date      varchar;
     v_message       varchar;
@@ -57,9 +56,8 @@ begin
     elseif (v_root_task_state = 'SUCCEEDED') then
         -- Get the count of loaded record types and total rows loaded.
         select
-            coalesce(count(distinct table_name), 0),
-            coalesce(sum(row_count), 0)
-        into :v_loaded, :v_total_rows
+            coalesce(count(distinct table_name), 0)
+        into :v_loaded
         from {{database_name}}.information_schema.load_history
         where schema_name = 'RDS_LANDING'
         -- TODO: This filter makes sure we're only counting rows for tasks that loaded stuff after the root task was run,
@@ -83,7 +81,6 @@ begin
                 || '*' || v_loaded || '*' || '/157 record types loaded · '
                 || '*' || v_failed || '*' || ' failed: ' || v_failed_names
                 || ' · *Graph Run Group ID*: ' || :v_graph_run_group_id
-                || ' · ' || '*' || v_total_rows || '*' || ' rows total'
                 || ' · *Root Task Scheduled Time*: ' || to_varchar(:v_root_task_scheduled_time)
                 || ' · *Root Task Query Start Time*: ' || to_varchar(:v_root_task_query_start_time)
                 || ' · *Root Task Completed Time*: ' || to_varchar(:v_root_task_completed_time)
@@ -92,7 +89,6 @@ begin
             -- Root task succeeded and all child tasks passed — full success.
             v_message := '✅ RDS snapshot ingestion complete — '
                 || '*' || v_loaded || '*' || '/157 record types loaded · '
-                || '*' || v_total_rows || '*' || ' rows total'
                 || ' · *Root Task Scheduled Time*: ' || to_varchar(:v_root_task_scheduled_time)
                 || ' · *Root Task Query Start Time*: ' || to_varchar(:v_root_task_query_start_time)
                 || ' · *Root Task Completed Time*: ' || to_varchar(:v_root_task_completed_time)

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -1,12 +1,12 @@
 use schema {{database_name}}.rds_landing; --noqa: JJ01,PRS,TMP
 
 -- Suspend root before modifying the graph.
-alter task refresh_stage_task suspend;
+alter task refresh_rds_snapshots_stage_task suspend;
 
 -- Create the finalizer task.
 create or replace task refresh_stage_finalizer_task
     user_task_managed_initial_warehouse_size = 'XSMALL'
-    finalize = 'refresh_stage_task'
+    finalize = 'refresh_rds_snapshots_stage_task'
 as
 execute immediate $$
 declare
@@ -35,8 +35,9 @@ begin
         completed_time
     into :v_root_task_id, :v_graph_run_group_id, :v_root_task_state, :v_root_task_scheduled_time, :v_root_task_query_start_time, :v_root_task_completed_time
     from table(snowflake.information_schema.task_history())
-    where upper(name) = 'REFRESH_STAGE_TASK'
+    where upper(name) = 'REFRESH_RDS_SNAPSHOTS_STAGE_TASK'
     and upper(database_name) = upper('{{database_name}}') --noqa: JJ01,PRS,TMP
+    and upper(schema_name) = 'RDS_LANDING'
     qualify row_number() over (order by scheduled_time desc, query_start_time desc) = 1;
 
     -----------------------------------------------------------------------------------------------------------------------
@@ -114,4 +115,4 @@ $$;
 alter task refresh_stage_finalizer_task resume;
 
 -- Re-enable the full RDS snapshot task graph from the root.
-select system$task_dependents_enable('refresh_stage_task');
+select system$task_dependents_enable('refresh_rds_snapshots_stage_task');

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -61,7 +61,7 @@ begin
             coalesce(sum(row_count), 0)
         into :v_loaded, :v_total_rows
         from {{database_name}}.information_schema.load_history
-        and schema_name = 'RDS_LANDING'
+        where schema_name = 'RDS_LANDING'
         -- TODO: This filter makes sure we're only counting rows for tasks that loaded stuff after the root task was run,
         --       but it doesn't guarantee that the loads were all part of the same graph run. Find a way to set an upper
         --       bound to ensure all loads are from the same graph run.

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -12,6 +12,7 @@ execute immediate $$
 declare
     v_graph_status  varchar;
     v_root_task_id  varchar;
+    v_graph_run_group_id varchar;
     v_start_time    timestamp_ltz;
     v_loaded        integer default 0;
     v_failed        integer default 0;
@@ -27,36 +28,50 @@ begin
         select system$task_runtime_info('CURRENT_TASK_GRAPH_ORIGINAL_SCHEDULED_TIMESTAMP')::timestamp_ltz
     );
 
+        select graph_run_group_id
+        into :v_graph_run_group_id
+        from snowflake.account_usage.task_history
+        where root_task_id = :v_root_task_id
+            and scheduled_time >= :v_start_time
+            and scheduled_time <= current_timestamp()
+        qualify row_number() over (order by scheduled_time desc) = 1;
+
     select
         case
-            when count_if(upper(state) like 'FAIL%') > 0 then 'failed'
-            when count_if(upper(state) like 'CANCEL%') > 0 then 'cancelled'
-            when count_if(upper(state) like 'SUCCEED%') > 0 then 'succeeded'
+                        when count_if(upper(status) = 'FAILED') > 0 then 'failed'
+                        when count_if(upper(status) = 'CANCELED') > 0 then 'cancelled'
+                        when count_if(upper(status) = 'SUCCEEDED') > 0 then 'succeeded'
             else 'unknown'
         end
     into :v_graph_status
-    from table(information_schema.task_history(
-        root_task_id => :v_root_task_id,
-        scheduled_time_range_start => :v_start_time,
-        scheduled_time_range_end => current_timestamp()
-    ));
+    from snowflake.account_usage.task_history
+        where graph_run_group_id = :v_graph_run_group_id
+            and root_task_id = :v_root_task_id
+      and scheduled_time >= :v_start_time
+      and scheduled_time <= current_timestamp();
 
     v_run_date     := to_varchar(current_date(), 'MM/DD/YYYY');
 
-    if (v_graph_status != 'succeeded') then
-        v_message := '🔴 RDS snapshot ingestion FAILED — graph state: ' || v_graph_status
-            || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
-    else
+    if (v_graph_status = 'succeeded') then
         select
-            coalesce(sum(case when status = 'Loaded' then 1 else 0 end), 0),
-            coalesce(sum(case when status != 'Loaded' then 1 else 0 end), 0),
-            coalesce(sum(row_count), 0),
-            listagg(case when status != 'Loaded' then table_name end, ', ')
-                within group (order by table_name)
-        into :v_loaded, :v_failed, :v_total_rows, :v_failed_names
-        from information_schema.copy_history
+            coalesce(count(*), 0),
+            coalesce(sum(row_count), 0)
+        into :v_loaded, :v_total_rows
+        from snowflake.account_usage.load_history
         where schema_name = 'RDS_LANDING'
           and last_load_time >= dateadd('hour', -25, current_timestamp());
+
+        select
+            coalesce(count_if(upper(status) = 'FAILED'), 0),
+            listagg(case when upper(status) = 'FAILED' then name end, ', ')
+                within group (order by name)
+        into :v_failed, :v_failed_names
+        from snowflake.account_usage.task_history
+        where graph_run_group_id = :v_graph_run_group_id
+          and root_task_id = :v_root_task_id
+          and scheduled_time >= :v_start_time
+          and scheduled_time <= current_timestamp()
+          and upper(name) != 'RDS_SNAPSHOT_FINALIZER_TASK';
 
         if (v_failed = 0) then
             v_message := '✅ RDS snapshot ingestion complete — '
@@ -68,6 +83,13 @@ begin
                 || v_failed || ' failed: ' || v_failed_names
                 || ' - Run date: ' || v_run_date || ' — [TODO: tag team]';
         end if;
+    elseif (v_graph_status = 'failed') then
+        v_message := '🔴 RDS snapshot ingestion FAILED — graph state: ' || v_graph_status
+            || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
+    else
+        v_message := '⚠️ No graph status retrieved. DPE team please view task statuses in '
+            || 'snowflake.account_usage.task_history'
+            || ' · Run date: ' || v_run_date || ' — [TODO: tag team]';
     end if;
 
     call system$send_snowflake_notification(

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -13,9 +13,9 @@ declare
     v_root_task_id       varchar;
     v_root_task_state    varchar;
     v_graph_run_group_id varchar;
-    v_scheduled_time     timestamp_ltz;
-    v_query_start_time   timestamp_ltz;
-    v_completed_time     timestamp_ltz;
+    v_root_task_scheduled_time   timestamp_ltz;
+    v_root_task_query_start_time timestamp_ltz;
+    v_root_task_completed_time   timestamp_ltz;
     v_loaded        integer default 0;
     v_failed        integer default 0;
     v_total_rows    integer default 0;
@@ -34,7 +34,7 @@ begin
         scheduled_time,
         query_start_time,
         completed_time
-    into :v_root_task_id, :v_graph_run_group_id, :v_root_task_state, :v_scheduled_time, :v_query_start_time, :v_completed_time
+    into :v_root_task_id, :v_graph_run_group_id, :v_root_task_state, :v_root_task_scheduled_time, :v_root_task_query_start_time, :v_root_task_completed_time
     from snowflake.account_usage.task_history
     where upper(name) = 'REFRESH_STAGE_TASK'
     and upper(database_name) = upper('{{database_name}}')
@@ -50,9 +50,9 @@ begin
         v_message := '🔴 RDS snapshot ingestion FAILED — root task failed'
             || ' · *Root Task ID*: ' || :v_root_task_id
             || ' · *Graph Run Group ID*: ' || :v_graph_run_group_id
-            || ' · *Scheduled Time*: ' || to_varchar(:v_scheduled_time)
-            || ' · *Query Start Time*: ' || to_varchar(:v_query_start_time)
-            || ' · *Completed Time*: ' || to_varchar(:v_completed_time)
+            || ' · *Root Task Scheduled Time*: ' || to_varchar(:v_root_task_scheduled_time)
+            || ' · *Root Task Query Start Time*: ' || to_varchar(:v_root_task_query_start_time)
+            || ' · *Root Task Completed Time*: ' || to_varchar(:v_root_task_completed_time)
             || ' · *Run date*: ' || v_run_date || ' — @team-dpe';
     elseif (v_root_task_state = 'SUCCEEDED') then
         -- Get the count of loaded record types and total rows loaded.
@@ -66,7 +66,7 @@ begin
         -- TODO: This filter makes sure we're only counting rows for tasks that loaded stuff after the root task was run,
         --       but it doesn't guarantee that the loads were all part of the same graph run. Find a way to set an upper
         --       bound to ensure all loads are from the same graph run.
-        and last_load_time >= :v_scheduled_time;
+        and last_load_time >= :v_root_task_scheduled_time;
 
         -- Get the failed child tasks, if any.
         select
@@ -85,12 +85,19 @@ begin
                 || '*' || v_failed || '*' || ' failed: ' || v_failed_names
                 || ' · *Graph Run Group ID*: ' || :v_graph_run_group_id
                 || ' · ' || '*' || v_total_rows || '*' || ' rows total'
+                || ' · *Root Task Scheduled Time*: ' || to_varchar(:v_root_task_scheduled_time)
+                || ' · *Root Task Query Start Time*: ' || to_varchar(:v_root_task_query_start_time)
+                || ' · *Root Task Completed Time*: ' || to_varchar(:v_root_task_completed_time)
                 || ' · *Run date*: ' || v_run_date || ' — @team-dpe';
         else
             -- Root task succeeded and all child tasks passed — full success.
             v_message := '✅ RDS snapshot ingestion complete — '
                 || '*' || v_loaded || '*' || '/157 record types loaded · '
-                || '*' || v_total_rows || '*' || ' rows total · *Run date*: ' || v_run_date;
+                || '*' || v_total_rows || '*' || ' rows total'
+                || ' · *Root Task Scheduled Time*: ' || to_varchar(:v_root_task_scheduled_time)
+                || ' · *Root Task Query Start Time*: ' || to_varchar(:v_root_task_query_start_time)
+                || ' · *Root Task Completed Time*: ' || to_varchar(:v_root_task_completed_time)
+                || ' · *Run date*: ' || v_run_date;
         end if;
     else
         v_message := '⚠️ No graph status retrieved. DPE team please view task statuses in '

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -38,9 +38,9 @@ begin
 
     select
         case
-                        when count_if(upper(status) = 'FAILED') > 0 then 'failed'
-                        when count_if(upper(status) = 'CANCELED') > 0 then 'cancelled'
-                        when count_if(upper(status) = 'SUCCEEDED') > 0 then 'succeeded'
+                        when count_if(upper(state) = 'FAILED') > 0 then 'failed'
+                        when count_if(upper(state) = 'CANCELED') > 0 then 'cancelled'
+                        when count_if(upper(state) = 'SUCCEEDED') > 0 then 'succeeded'
             else 'unknown'
         end
     into :v_graph_status
@@ -62,8 +62,8 @@ begin
           and last_load_time >= dateadd('hour', -25, current_timestamp());
 
         select
-            coalesce(count_if(upper(status) = 'FAILED'), 0),
-            listagg(case when upper(status) = 'FAILED' then name end, ', ')
+            coalesce(count_if(upper(state) = 'FAILED'), 0),
+            listagg(case when upper(state) = 'FAILED' then name end, ', ')
                 within group (order by name)
         into :v_failed, :v_failed_names
         from snowflake.account_usage.task_history

--- a/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
+++ b/synapse_data_warehouse/rds_landing/V2.71.3__create_rds_snapshot_finalizer_task.sql
@@ -72,7 +72,8 @@ begin
 
     call system$send_snowflake_notification(
         snowflake.notification.text_plain(:v_message),
-        snowflake.notification.integration('SLACK_INGEST_UPDATES')
+        -- TODO: point to prod integration when ready
+        snowflake.notification.integration('DEV_SLACK_INGEST_UPDATES')
     );
 
     return :v_message;


### PR DESCRIPTION
<!-- REQUIRED -->
<!-- The title of this PR must be prefixed with the Jira ticket -->
<!-- e.g., "[] My brief title" -->
# Problem

https://sagebionetworks.jira.com/browse/SNOW-473

# Solution

As part of observability into the health of the task graph, we implement a finalizer task that will run regardless of whether or not the root task and/or its child tasks fail. This finalizer task provides engineers and other stakeholders with a summary on the status of the latest task graph run, and surface high level details on graph runs that failed or partially succeeded.

# Testing

### Tests completed for this PR:
- [x] Ensure the finalizer task still runs and sends a report even when root task fails
- [x] Test the partial success scenario

<!-- Describe any testing that was performed to validate the solution. -->
<img width="1509" height="281" alt="image" src="https://github.com/user-attachments/assets/c8fd1f98-cd12-40b0-8e9a-0b5fc2dfced4" />

### Tests remaining:
- [ ] Test a full success scenario. This will be tested in the main feature branch for the RDS snapshots task dag.