### PR TITLE
[SNOW-477] Update CI actions

### DIFF
--- a/.github/actions/configure-snowflake-cli/action.yml
+++ b/.github/actions/configure-snowflake-cli/action.yml
@@ -91,12 +91,12 @@ runs:
         cat $CONNECTION_FILE
         
     - name: Configure Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 
     - name: Install Snowflake CLI
-      uses: Snowflake-Labs/snowflake-cli-action@v1.5
+      uses: Snowflake-Labs/snowflake-cli-action@18d88e589d4df312334083e08cc408b68641fd5a  # v1.5
 
     - name: install-schemachange
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     environment: dev
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Snowflake
         uses: ./.github/actions/configure-snowflake-cli
@@ -55,7 +55,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Snowflake
         uses: ./.github/actions/configure-snowflake-cli
@@ -87,7 +87,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Snowflake
         uses: ./.github/actions/configure-snowflake-cli
@@ -122,7 +122,7 @@ jobs:
             role: sage_elite_admin
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Snowflake
         uses: ./.github/actions/configure-snowflake-cli
@@ -144,7 +144,7 @@ jobs:
     if: github.ref_name == 'main'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Snowflake
         uses: ./.github/actions/configure-snowflake-cli
@@ -197,7 +197,7 @@ jobs:
       PRIVATE_KEY_PASSPHRASE: ${{ secrets.ADMIN_SERVICE_PASS_PHRASE }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Snowflake
         uses: ./.github/actions/configure-snowflake-cli

--- a/.github/workflows/test_with_clone.yaml
+++ b/.github/workflows/test_with_clone.yaml
@@ -50,7 +50,7 @@ jobs:
             ############################ ENVIRONMENT SETUP AND CONNECTION CONFIGURATION ############################
             ########################################################################################################
             ########################################################################################################
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Configure Snowflake
               uses: ./.github/actions/configure-snowflake-cli
@@ -203,7 +203,7 @@ jobs:
 
       steps:
 
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v6
 
           - name: Configure Snowflake
             uses: ./.github/actions/configure-snowflake-cli


### PR DESCRIPTION
# Problem

GitHub Actions are using Node.js 20, which will be deprecated on June 2nd, 2026 and removed on September 16th, 2026. Deprecation warnings appeared during dev deployments.

Ticket: [SNOW-477](https://sagebionetworks.jira.com/browse/SNOW-477)

# Solution

Updated all GitHub Actions to Node.js 24 compatible versions:

1. **Update actions to latest version**
   * Updated `actions/checkout` from v4 to v6 in [ci.yaml](https://github.com/Sage-Bionetworks/snowflake/blob/snow-477-update-ci-actions/.github/workflows/ci.yaml) and [test_with_clone.yaml](https://github.com/Sage-Bionetworks/snowflake/blob/snow-477-update-ci-actions/.github/workflows/test_with_clone.yaml)
   * Updated `actions/setup-python` from v5 to v6 in [configure-snowflake-cli action](https://github.com/Sage-Bionetworks/snowflake/blob/snow-477-update-ci-actions/.github/actions/configure-snowflake-cli/action.yml#L94)

2. **Pin non-GitHub maintained actions to SHA hashes**
   * Pinned `Snowflake-Labs/snowflake-cli-action` to SHA `18d88e589d4df312334083e08cc408b68641fd5a` (v1.5) in [configure-snowflake-cli action](https://github.com/Sage-Bionetworks/snowflake/blob/snow-477-update-ci-actions/.github/actions/configure-snowflake-cli/action.yml#L99)

GitHub-maintained actions use major version pinning (v6) for automatic minor/patch updates. Third-party actions are SHA-pinned for security.

# Testing

Changes will be validated by:
1. This PR triggering `test_with_clone.yaml` workflow with updated actions
2. Verifying no Node.js 20 deprecation warnings in Actions logs
3. Confirming all workflow jobs complete successfully
4. Testing deployment to dev environment after merge

[SNOW-477]: https://sagebionetworks.jira.com/browse/SNOW-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ