### PR TITLE
Add data size distribution and user demographics to NF usage metrics dashboard

### DIFF
--- a/sage/nf/streamlit/nf_usage_metrics/streamlit_app.py
+++ b/sage/nf/streamlit/nf_usage_metrics/streamlit_app.py
@@ -25,6 +25,7 @@ from toolkit.queries import (
     query_total_data_size_by_initiative,
     query_top_data_types_by_size,
     query_released_data_by_type,
+    query_user_demographics,
 )
 from toolkit.utils import get_data_from_snowflake
 from toolkit.widgets import (
@@ -43,6 +44,8 @@ from toolkit.widgets import (
     plot_data_type_bar_chart,
     create_data_type_table,
     format_size_metric,
+    plot_project_size_distribution,
+    plot_user_demographics,
     # TRANSFORMS
     merge_size_and_downloads,
     # PALETTE
@@ -459,6 +462,16 @@ def main():
                 )
             st.plotly_chart(plot_stacked_bar_chart(filtered_project_meta))
 
+            # Data Size Distribution by Storage Tier (NTAP feedback, Task 2.4) ------------------#
+            st.subheader("Data Size Distribution by Storage Tier")
+            sizes_df = get_data_from_snowflake(query_project_sizes(project_ids))
+            if sizes_df.empty:
+                st.warning("No project size data available for the selected projects.")
+            else:
+                st.plotly_chart(
+                    plot_project_size_distribution(sizes_df, filtered_project_meta)
+                )
+
             # Data Release Report ---------------------------------------------------------------#
             st.header("Data Release")
 
@@ -657,6 +670,16 @@ def main():
 
                     # How many unique users are downloading data for each project monthly?
                     st.plotly_chart(plot_unique_users_monthly(unique_users_df))
+
+                # User Demographics (NTAP feedback, Task 2.4) -------------------------------------#
+                st.subheader("User Demographics")
+                demo_df = get_data_from_snowflake(
+                    query_user_demographics(project_ids, start_date, end_date)
+                )
+                if demo_df.empty:
+                    st.warning("No user demographic data available for the selected projects.")
+                else:
+                    st.plotly_chart(plot_user_demographics(demo_df))
 
                 # Cumulative Data Growth ---------------------------------------------------------------#
                 st.header("Cumulative Data Growth")

--- a/sage/nf/streamlit/nf_usage_metrics/toolkit/queries.py
+++ b/sage/nf/streamlit/nf_usage_metrics/toolkit/queries.py
@@ -687,3 +687,35 @@ def query_released_data_by_type(project_ids, released_statuses=None, limit=5):
         data_type ASC
     LIMIT {limit};
     """
+
+
+def query_user_demographics(project_ids, start_date, end_date, excluded_users=STAFF_USERIDS):
+    """
+    Return user profile info (company, email, location) for all non-staff downloaders
+    within the given projects and date window. Used to classify users by sector
+    (Academic/Industry/International) per NTAP feedback on the Task 2.4 Project
+    Analytics Report.
+    """
+    project_list = ", ".join(f"'{id}'" for id in project_ids)
+    excluded = ", ".join(map(str, excluded_users))
+
+    return f"""
+    WITH downloaders AS (
+        SELECT DISTINCT od.user_id
+        FROM synapse_data_warehouse.synapse_event.objectdownload_event od
+        WHERE od.project_id IN ({project_list})
+          AND od.record_date BETWEEN '{start_date}' AND '{end_date}'
+          AND od.user_id NOT IN ({excluded})
+    )
+    SELECT
+        d.user_id,
+        up.company,
+        up.email,
+        up.location
+    FROM downloaders d
+    LEFT JOIN synapse_data_warehouse.synapse.userprofile_latest up
+        ON up.id = d.user_id
+    WHERE (up.email IS NULL
+       OR (up.email NOT ILIKE '%@sagebase.org'
+           AND up.email NOT ILIKE '%@sagebionetworks.org'))
+    """

--- a/sage/nf/streamlit/nf_usage_metrics/toolkit/widgets.py
+++ b/sage/nf/streamlit/nf_usage_metrics/toolkit/widgets.py
@@ -997,3 +997,190 @@ def format_size_metric(bytes_value):
         return bytes_value / (1024**2), "MB"
     else:
         return bytes_value, "Bytes"
+
+
+# ── Size-distribution chart (NTAP feedback, Task 2.4) ───────────────────────#
+
+SIZE_TIERS = [
+    ("≤100 GB",       0,                    100  * 1024**3),
+    (">100 GB – 1 TB", 100 * 1024**3,       1    * 1024**4),
+    (">1 – 10 TB",     1   * 1024**4,       10   * 1024**4),
+    (">10 – 100 TB",   10  * 1024**4,       100  * 1024**4),
+    (">100 TB",        100 * 1024**4,       float("inf")),
+]
+
+def assign_size_tier(bytes_val):
+    for label, lo, hi in SIZE_TIERS:
+        if lo < bytes_val <= hi or (lo == 0 and bytes_val <= hi):
+            return label
+    return ">100 TB"
+
+
+def plot_project_size_distribution(sizes_df: pd.DataFrame,
+                                   meta_df: pd.DataFrame,
+                                   width: int = 900) -> go.Figure:
+    """
+    Grouped bar chart: project count per storage-tier (rows) × study status (groups).
+
+    Parameters
+    ----------
+    sizes_df : DataFrame with PROJECT_ID and TOTAL_CONTENT_SIZE (bytes)
+    meta_df  : DataFrame with PROJECT_ID and STUDY_STATUS
+    """
+    if sizes_df.empty:
+        return go.Figure()
+
+    df = sizes_df.merge(
+        meta_df[["PROJECT_ID", "STUDY_STATUS"]].drop_duplicates(),
+        on="PROJECT_ID", how="left"
+    )
+    df["SIZE_TIER"] = df["TOTAL_CONTENT_SIZE"].fillna(0).apply(assign_size_tier)
+    df["STUDY_STATUS"] = df["STUDY_STATUS"].fillna("Unknown")
+
+    tier_order = [t[0] for t in SIZE_TIERS]
+    counts = (
+        df.groupby(["SIZE_TIER", "STUDY_STATUS"])
+        .size()
+        .reset_index(name="COUNT")
+    )
+    counts["SIZE_TIER"] = pd.Categorical(counts["SIZE_TIER"], categories=tier_order, ordered=True)
+    counts = counts.sort_values("SIZE_TIER")
+
+    status_colors = {"Active": PORTAL_BLUE, "Completed": TEAL, "Unknown": GRAY}
+
+    fig = go.Figure()
+    for status in counts["STUDY_STATUS"].unique():
+        sub = counts[counts["STUDY_STATUS"] == status]
+        # fill missing tiers with 0
+        full = pd.DataFrame({"SIZE_TIER": tier_order})
+        full = full.merge(sub[["SIZE_TIER", "COUNT"]], on="SIZE_TIER", how="left").fillna(0)
+        fig.add_trace(go.Bar(
+            name=status,
+            x=full["SIZE_TIER"],
+            y=full["COUNT"],
+            marker_color=status_colors.get(status, GRAY),
+            text=full["COUNT"].astype(int),
+            textposition="outside",
+        ))
+
+    fig.update_layout(
+        barmode="group",
+        xaxis_title="Storage Tier",
+        yaxis_title="Number of Projects",
+        legend_title="Project Status",
+        width=width,
+        height=420,
+        margin=dict(l=60, r=60, t=40, b=60),
+        annotations=[dict(
+            text=(
+                "Pricing tiers per contract: ≤100 GB included in base fee · "
+                ">100 GB–1 TB: $7,500 · >1–10 TB: $10,500 · >10–100 TB: $26,500"
+            ),
+            xref="paper", yref="paper",
+            x=0, y=-0.22,
+            showarrow=False,
+            font=dict(size=10, color=GRAY),
+            align="left",
+        )],
+    )
+    return fig
+
+
+# ── User-demographics chart (NTAP feedback, Task 2.4) ───────────────────────#
+
+ACADEMIC_KEYWORDS = [
+    "university", "université", "universität", "universidad",
+    "college", "school of", "institute", "institut",
+    "hospital", "clinic", "medical center", "health system",
+    "children's", "pediatric", "cancer center",
+    "nih", "nci", "nhgri", "ninds", "nimh", "niaid",
+    "cdc", "fda", "hhs", "nhs",
+    "foundation", "non-profit", "nonprofit",
+    "research center", "research institute",
+    "academy", "académie",
+]
+
+INDUSTRY_KEYWORDS = [
+    "pharma", "pharmaceutical", "therapeutics", "biosciences", "biotech",
+    "genentech", "pfizer", "roche", "novartis", "merck", "abbvie",
+    "bristol-myers", "astrazeneca", "sanofi", "bayer",
+    " inc", " inc.", " corp", " corp.", " ltd", " llc",
+    "biomed", "biomedicine", "drug", "biomedical",
+]
+
+US_DOMAINS = {".edu", ".gov", ".mil", ".org"}
+
+
+def classify_user(company: str, email: str, location: str) -> str:
+    """Return 'Academic', 'Industry', 'International', or 'Unknown'."""
+    c = (company or "").lower()
+    e = (email or "").lower()
+    loc = (location or "").lower()
+
+    if any(kw in c for kw in ACADEMIC_KEYWORDS):
+        return "Academic / Non-profit"
+    if any(kw in c for kw in INDUSTRY_KEYWORDS):
+        return "Industry / Pharma"
+
+    # Email-domain heuristic
+    domain = e.rsplit("@", 1)[-1] if "@" in e else ""
+    if domain.endswith(".edu") or domain.endswith(".gov") or domain.endswith(".org"):
+        return "Academic / Non-profit"
+    tld = "." + domain.rsplit(".", 1)[-1] if "." in domain else ""
+    if tld not in ("", ".com", ".net", ".edu", ".gov", ".org", ".mil"):
+        return "International"
+
+    # Location heuristic (non-blank, non-US)
+    us_terms = {"usa", "united states", "u.s.", "u.s.a", "us"}
+    if loc and not any(t in loc for t in us_terms) and loc not in ("", "none"):
+        return "International"
+
+    return "Unknown / Other"
+
+
+def plot_user_demographics(demo_df: pd.DataFrame, width: int = 700) -> go.Figure:
+    """
+    Horizontal bar chart of user counts by sector classification.
+
+    Parameters
+    ----------
+    demo_df : DataFrame with columns USER_ID, COMPANY, EMAIL, LOCATION
+    """
+    if demo_df.empty:
+        return go.Figure()
+
+    demo_df = demo_df.copy()
+    demo_df["SECTOR"] = demo_df.apply(
+        lambda r: classify_user(
+            r.get("COMPANY", ""), r.get("EMAIL", ""), r.get("LOCATION", "")
+        ),
+        axis=1,
+    )
+
+    counts = demo_df.groupby("SECTOR")["USER_ID"].nunique().reset_index(name="USERS")
+    counts = counts.sort_values("USERS", ascending=True)
+
+    sector_colors = {
+        "Academic / Non-profit": PORTAL_BLUE,
+        "Industry / Pharma":     ORANGE,
+        "International":         TEAL,
+        "Unknown / Other":       GRAY,
+    }
+    colors = [sector_colors.get(s, GRAY) for s in counts["SECTOR"]]
+
+    fig = go.Figure(go.Bar(
+        x=counts["USERS"],
+        y=counts["SECTOR"],
+        orientation="h",
+        marker_color=colors,
+        text=counts["USERS"],
+        textposition="outside",
+    ))
+    fig.update_layout(
+        xaxis_title="Unique Users",
+        yaxis_title="",
+        width=width,
+        height=320,
+        margin=dict(l=180, r=80, t=30, b=50),
+    )
+    return fig


### PR DESCRIPTION
## Summary

NTAP gave feedback on the Task 2.4 Project Analytics Report (Milestone 1 review, June 2026) requesting two additions to the NF usage-metrics dashboard, scoped entirely to `sage/nf/streamlit/nf_usage_metrics/` — no other funder's dashboard in this repo is touched:

- *"Would you include a graph or table showing the data sizes for all 99 projects (completed vs active)? ... up to 100 GB, up to 1 TB, up to 10 TB, up to 100 TB, or over 100 TB."*
- *"It would also be helpful to know more information about the 99 unique users of that data – from pharma, academia, and international."*

## Changes

- `toolkit/queries.py`: `query_user_demographics()` — non-staff downloader profiles (company/email/location) for a project set + date window, excluding Sage staff by email domain.
- `toolkit/widgets.py`: `SIZE_TIERS`/`assign_size_tier()`/`plot_project_size_distribution()` (grouped bar chart, storage tier × Active/Completed status, with contract pricing-tier annotations) and `classify_user()`/`plot_user_demographics()` (sector-classification bar chart via institution keywords → email-domain TLD → location fallback).
- `streamlit_app.py`: wires both in — a new "Data Size Distribution by Storage Tier" subsection after the existing Active/Completed status breakdown, and a new "User Demographics" subsection after the existing Users Network chart.

## Context

Originally developed on `nf-osi/snowflake-streamlit` PR #54 (draft, unmerged) before that repo was slated for archival. Ported here since this app's structure already matched closely — same `toolkit/queries.py`/`toolkit/widgets.py` split, same `userprofile_latest`/`objectdownload_event` tables, same color palette constants — so the port needed no structural adaptation, just re-pointing at this repo's existing helpers.

Opened as a draft since it's an unreviewed cross-team port — happy to adjust chart placement/styling to match whatever conventions this app already follows elsewhere.

## Test plan

- [ ] Run the app locally, select NTAP, and confirm "Data Size Distribution by Storage Tier" renders below the existing project-status breakdown
- [ ] Confirm "User Demographics" renders below the existing Users Network section
- [ ] Confirm Sage staff emails are excluded from demographics counts
- [ ] Spot check a few known non-US users classify as "International"

🤖 Generated with [Claude Code](https://claude.com/claude-code)