### PR TITLE
Add Data Lifecycle tab (EOL candidates + S3 tier analysis) to NF usage metrics

### DIFF
--- a/sage/nf/streamlit/nf_usage_metrics/streamlit_app.py
+++ b/sage/nf/streamlit/nf_usage_metrics/streamlit_app.py
@@ -22,6 +22,8 @@ from toolkit.queries import (
     query_project_sizes,
     query_unique_users,
     query_file_metadata_for_growth,
+    query_file_eol_analysis,
+    query_s3_tier_all_portal,
     query_total_data_size_by_initiative,
     query_top_data_types_by_size,
     query_released_data_by_type,
@@ -43,6 +45,11 @@ from toolkit.widgets import (
     plot_data_type_bar_chart,
     create_data_type_table,
     format_size_metric,
+    plot_never_downloaded_by_project,
+    plot_eol_scatter,
+    plot_eol_never_downloaded,
+    plot_eol_stale_downloads,
+    plot_s3_tier_estimate,
     # TRANSFORMS
     merge_size_and_downloads,
     # PALETTE
@@ -395,437 +402,533 @@ def main():
                 st.warning("No projects match the selected data status filters.")
                 return
 
-            st.header("Reference Overview")
+            tab1, tab2 = st.tabs(["📊 Data Analytics", "⏳ Data Lifecycle"])
 
-            with st.expander("Glossary"):
-                st.markdown("""
-                    #### Project Status
+            with tab1:
+                st.header("Reference Overview")
 
-                    - **Active**: The project is in the performance period (between grant start and grant end dates).
-                    - **Completed**: The project has reached the grant end date and gone through a closeout process as requested by NTAP.
-                    - **Withdrawn**: The project was planned/started but not completed (withdrawn).
+                with st.expander("Glossary"):
+                    st.markdown("""
+                        #### Project Status
 
-                    #### Data Status
+                        - **Active**: The project is in the performance period (between grant start and grant end dates).
+                        - **Completed**: The project has reached the grant end date and gone through a closeout process as requested by NTAP.
+                        - **Withdrawn**: The project was planned/started but not completed (withdrawn).
 
-                    - **None**: There is no available data for the project.
-                    - **Data Not Expected**: There is no available data for the project because data is not expected to be stored for this project.
-                    - **Data Pending**: Data is pending for the project, either still being generated or has not yet been uploaded to Synapse yet, so there are no files in the project.
-                    - **Under Embargo**: Data is present in the project but not accessible to anyone outside the project admins. When data is first uploaded, the status will change from "Data Pending" to "Under Embargo".
-                    - **Rolling Release**: Some data is available for download for the project via rolling release.
-                    - **Partially Available**: Some data is available for download for the project.
-                    - **Available**: Data is fully available for download for the project.
-                    """)
+                        #### Data Status
 
-            # Project Reference Table ----------------------------------------------------------#
-            with st.expander("Projects included in reporting"):
-                reference_df = filtered_project_meta.reset_index(drop=True)
-                st.table(reference_df)
+                        - **None**: There is no available data for the project.
+                        - **Data Not Expected**: There is no available data for the project because data is not expected to be stored for this project.
+                        - **Data Pending**: Data is pending for the project, either still being generated or has not yet been uploaded to Synapse yet, so there are no files in the project.
+                        - **Under Embargo**: Data is present in the project but not accessible to anyone outside the project admins. When data is first uploaded, the status will change from "Data Pending" to "Under Embargo".
+                        - **Rolling Release**: Some data is available for download for the project via rolling release.
+                        - **Partially Available**: Some data is available for download for the project.
+                        - **Available**: Data is fully available for download for the project.
+                        """)
 
-            # What does overall project portfolio look like when grouped solely by data status ontology
-            st.subheader("Data Status Distribution")
-            data_status_flow = graphviz_status(
-                filtered_project_meta["DATA_STATUS"].tolist()
-            )
-            with st.container():
-                col1, col2 = st.columns([1, 1])
+                # Project Reference Table ----------------------------------------------------------#
+                with st.expander("Projects included in reporting"):
+                    reference_df = filtered_project_meta.reset_index(drop=True)
+                    st.table(reference_df)
+
+                # What does overall project portfolio look like when grouped solely by data status ontology
+                st.subheader("Data Status Distribution")
+                data_status_flow = graphviz_status(
+                    filtered_project_meta["DATA_STATUS"].tolist()
+                )
+                with st.container():
+                    col1, col2 = st.columns([1, 1])
+                    with col1:
+                        st.graphviz_chart(data_status_flow, use_container_width=True)
+                    st.markdown(
+                        '<div style="padding-bottom: 40px;"></div>', unsafe_allow_html=True
+                    )
+
+                # How many active vs completed projects, and how many projects are in each data status
+                st.subheader(
+                    "Data Status Distribution, Comparing Active vs. Completed Projects"
+                )
+                col1, col2, col3 = st.columns([1, 1, 4])
                 with col1:
-                    st.graphviz_chart(data_status_flow, use_container_width=True)
-                st.markdown(
-                    '<div style="padding-bottom: 40px;"></div>', unsafe_allow_html=True
-                )
-
-            # How many active vs completed projects, and how many projects are in each data status
-            st.subheader(
-                "Data Status Distribution, Comparing Active vs. Completed Projects"
-            )
-            col1, col2, col3 = st.columns([1, 1, 4])
-            with col1:
-                st.metric(
-                    label="Active Projects",
-                    value=len(
-                        filtered_project_meta[
-                            filtered_project_meta["STUDY_STATUS"] == "Active"
-                        ]
-                    ),
-                )
-            with col2:
-                st.metric(
-                    label="Completed Projects",
-                    value=len(
-                        filtered_project_meta[
-                            filtered_project_meta["STUDY_STATUS"] == "Completed"
-                        ]
-                    ),
-                )
-            st.plotly_chart(plot_stacked_bar_chart(filtered_project_meta))
-
-            # Data Release Report ---------------------------------------------------------------#
-            st.header("Data Release")
-
-            # DF with grouped data
-            grouped_df = (
-                filtered_project_meta.groupby(["STUDY_STATUS", "DATA_STATUS"])
-                .size()
-                .reset_index(name="COUNT")
-            )
-
-            project_sizes = get_data_from_snowflake(query_project_sizes(project_ids))
-            if project_sizes.empty:
-                st.warning("No data sizes available for the selected projects.")
-                return
-
-            total_data_size_gib = project_sizes["TOTAL_CONTENT_SIZE"].sum()
-            total_data_size_tb = convert_to_tb(
-                project_sizes["TOTAL_CONTENT_SIZE"].sum()
-            )
-            average_project_size = round(
-                convert_to_gb(np.mean(project_sizes["TOTAL_CONTENT_SIZE"])), 2
-            )
-            annual_cost = calculate_annual_cost(total_data_size_gib)
-
-            # Metrics
-            col1, col2, col3 = st.columns([1, 1, 1])
-            col1.metric(
-                f"{', '.join(funders)} Projects With Target Data Status",
-                f"{len(project_ids)}",
-            )
-            col2.metric("Total Data in These Projects", f"{total_data_size_tb:,.2f} TB")
-            col3.metric("Avg. Project Size", f"{average_project_size} GB")
-
-            # Data Usage Report ---------------------------------------------------------------#
-            st.header("Data Usage")
-            st.subheader("General Overview")
-            if project_ids:
-                project_downloads_df = get_data_from_snowflake(
-                    query_project_downloads(project_ids, start_date, end_date)
-                )
-                if project_downloads_df.empty:
-                    st.warning("No download data available for the selected projects.")
-                else:
-                    total_downloads_gb = convert_to_gb(
-                        project_downloads_df["TOTAL_DOWNLOADS"].sum()
+                    st.metric(
+                        label="Active Projects",
+                        value=len(
+                            filtered_project_meta[
+                                filtered_project_meta["STUDY_STATUS"] == "Active"
+                            ]
+                        ),
                     )
-                    total_unique_files = project_downloads_df[
-                        "TOTAL_UNIQUE_FILEHANDLEIDS"
-                    ].sum()
-
-                    # Metrics
-                    col1, col2, col3 = st.columns([1, 1, 1])
-                    col1.metric("Number of Unique Files Requested", total_unique_files)
-                    col2.metric("Total Egressed Data", f"{total_downloads_gb:,.2f} GB")
-                    col3.metric(
-                        "Avg Downloads for Downloaded File",
-                        f"{(total_downloads_gb / total_unique_files) if total_unique_files else 0:,.2f} GB",
+                with col2:
+                    st.metric(
+                        label="Completed Projects",
+                        value=len(
+                            filtered_project_meta[
+                                filtered_project_meta["STUDY_STATUS"] == "Completed"
+                            ]
+                        ),
                     )
+                st.plotly_chart(plot_stacked_bar_chart(filtered_project_meta))
 
-                    # What does egress look like over selected timeframe?
-                    monthly_file_egress_df = get_data_from_snowflake(
-                        query_monthly_file_egress(project_ids, start_date, end_date)
+                # Data Release Report ---------------------------------------------------------------#
+                st.header("Data Release")
+
+                # DF with grouped data
+                grouped_df = (
+                    filtered_project_meta.groupby(["STUDY_STATUS", "DATA_STATUS"])
+                    .size()
+                    .reset_index(name="COUNT")
+                )
+
+                project_sizes = get_data_from_snowflake(query_project_sizes(project_ids))
+                if project_sizes.empty:
+                    st.warning("No data sizes available for the selected projects.")
+                    return
+
+                total_data_size_gib = project_sizes["TOTAL_CONTENT_SIZE"].sum()
+                total_data_size_tb = convert_to_tb(
+                    project_sizes["TOTAL_CONTENT_SIZE"].sum()
+                )
+                average_project_size = round(
+                    convert_to_gb(np.mean(project_sizes["TOTAL_CONTENT_SIZE"])), 2
+                )
+                annual_cost = calculate_annual_cost(total_data_size_gib)
+
+                # Metrics
+                col1, col2, col3 = st.columns([1, 1, 1])
+                col1.metric(
+                    f"{', '.join(funders)} Projects With Target Data Status",
+                    f"{len(project_ids)}",
+                )
+                col2.metric("Total Data in These Projects", f"{total_data_size_tb:,.2f} TB")
+                col3.metric("Avg. Project Size", f"{average_project_size} GB")
+
+                # Data Usage Report ---------------------------------------------------------------#
+                st.header("Data Usage")
+                st.subheader("General Overview")
+                if project_ids:
+                    project_downloads_df = get_data_from_snowflake(
+                        query_project_downloads(project_ids, start_date, end_date)
                     )
-                    if not monthly_file_egress_df.empty:
-                        monthly_file_egress_df = monthly_file_egress_df.merge(
+                    if project_downloads_df.empty:
+                        st.warning("No download data available for the selected projects.")
+                    else:
+                        total_downloads_gb = convert_to_gb(
+                            project_downloads_df["TOTAL_DOWNLOADS"].sum()
+                        )
+                        total_unique_files = project_downloads_df[
+                            "TOTAL_UNIQUE_FILEHANDLEIDS"
+                        ].sum()
+
+                        # Metrics
+                        col1, col2, col3 = st.columns([1, 1, 1])
+                        col1.metric("Number of Unique Files Requested", total_unique_files)
+                        col2.metric("Total Egressed Data", f"{total_downloads_gb:,.2f} GB")
+                        col3.metric(
+                            "Avg Downloads for Downloaded File",
+                            f"{(total_downloads_gb / total_unique_files) if total_unique_files else 0:,.2f} GB",
+                        )
+
+                        # What does egress look like over selected timeframe?
+                        monthly_file_egress_df = get_data_from_snowflake(
+                            query_monthly_file_egress(project_ids, start_date, end_date)
+                        )
+                        if not monthly_file_egress_df.empty:
+                            monthly_file_egress_df = monthly_file_egress_df.merge(
+                                filtered_project_meta[["PROJECT_ID", "PROJECT_NAME"]],
+                                on="PROJECT_ID",
+                                how="left",
+                            )
+                            st.plotly_chart(plot_monthly_egress(monthly_file_egress_df))
+
+                        st.subheader("Dissemination By Project")
+
+                        # Add project names
+                        project_sizes = project_sizes.merge(
                             filtered_project_meta[["PROJECT_ID", "PROJECT_NAME"]],
                             on="PROJECT_ID",
                             how="left",
                         )
-                        st.plotly_chart(plot_monthly_egress(monthly_file_egress_df))
 
-                    st.subheader("Dissemination By Project")
+                        merged_df = merge_size_and_downloads(
+                            project_sizes, project_downloads_df
+                        )
+                        merged_df = merged_df.dropna(
+                            subset=["TOTAL_CONTENT_SIZE", "TOTAL_DOWNLOADS"]
+                        )
 
-                    # Add project names
-                    project_sizes = project_sizes.merge(
-                        filtered_project_meta[["PROJECT_ID", "PROJECT_NAME"]],
-                        on="PROJECT_ID",
-                        how="left",
+                        # Two way display mean for downloads
+                        mean_downloads = convert_to_gb(merged_df["TOTAL_DOWNLOADS"].mean())
+                        nonzero_downloads = merged_df[merged_df["TOTAL_DOWNLOADS"] > 0]
+                        mean_filtered_download = convert_to_gb(
+                            nonzero_downloads["TOTAL_DOWNLOADS"].mean()
+                        )
+
+                        col1, col2, col3 = st.columns([1, 1, 1])
+                        col1.metric(
+                            "Number of projects that see downloads",
+                            f"{len(project_downloads_df)} out of {len(project_ids)}",
+                        )
+                        col2.metric(
+                            "Mean download size for downloaded projects",
+                            f"{mean_filtered_download:,.2f} GB",
+                        )
+
+                        st.plotly_chart(plot_download_scatter(merged_df))
+
+                        st.subheader("Characteristics of Disseminated Data")
+
+                        data_meta_df = get_data_from_snowflake(
+                            query_downloaded_file_meta(project_ids, start_date, end_date)
+                        )
+                        if data_meta_df.empty:
+                            st.warning("No data available for the selected criteria.")
+                        else:
+                            # Metrics
+                            col1, col2, col3 = st.columns([1, 1, 1])
+                            unique_assays = len(data_meta_df["ASSAY"].unique())
+                            delta_assays = (
+                                unique_assays - comp_assay_count
+                                if comp_assay_count is not None
+                                else None
+                            )
+                            col1.metric(
+                                "Number of Unique Assays", unique_assays, delta=delta_assays
+                            )
+                            col2.metric("", "")
+                            col3.metric("Avg. ", 3)
+
+                            # What are assays being downloaded?
+                            st.plotly_chart(
+                                plot_resource_downloads(
+                                    data_meta_df,
+                                    resource_column="ASSAY",
+                                    color=ORANGE,
+                                    title="Assays Being Downloaded",
+                                )
+                            )
+
+                            # What are resources being downloaded?
+                            st.plotly_chart(
+                                plot_resource_downloads(
+                                    data_meta_df,
+                                    resource_column="RESOURCE_TYPE",
+                                    color=PURPLE,
+                                    title="Resources Being Downloaded",
+                                )
+                            )
+
+                # User Network -----------------------------------------------------------------------#
+                st.header("Users Network")
+                if project_ids:
+                    unique_users_df = get_data_from_snowflake(
+                        query_unique_users(project_ids, start_date, end_date)
                     )
-
-                    merged_df = merge_size_and_downloads(
-                        project_sizes, project_downloads_df
-                    )
-                    merged_df = merged_df.dropna(
-                        subset=["TOTAL_CONTENT_SIZE", "TOTAL_DOWNLOADS"]
-                    )
-
-                    # Two way display mean for downloads
-                    mean_downloads = convert_to_gb(merged_df["TOTAL_DOWNLOADS"].mean())
-                    nonzero_downloads = merged_df[merged_df["TOTAL_DOWNLOADS"] > 0]
-                    mean_filtered_download = convert_to_gb(
-                        nonzero_downloads["TOTAL_DOWNLOADS"].mean()
-                    )
-
-                    col1, col2, col3 = st.columns([1, 1, 1])
-                    col1.metric(
-                        "Number of projects that see downloads",
-                        f"{len(project_downloads_df)} out of {len(project_ids)}",
-                    )
-                    col2.metric(
-                        "Mean download size for downloaded projects",
-                        f"{mean_filtered_download:,.2f} GB",
-                    )
-
-                    st.plotly_chart(plot_download_scatter(merged_df))
-
-                    st.subheader("Characteristics of Disseminated Data")
-
-                    data_meta_df = get_data_from_snowflake(
-                        query_downloaded_file_meta(project_ids, start_date, end_date)
-                    )
-                    if data_meta_df.empty:
-                        st.warning("No data available for the selected criteria.")
+                    if unique_users_df.empty:
+                        st.warning(
+                            "No unique user data available for the selected projects."
+                        )
                     else:
+                        unique_users_count = unique_users_df["USER_ID"].nunique()
+                        avg_users_per_project = (
+                            unique_users_count / len(project_downloads_df)
+                            if len(project_downloads_df) > 0
+                            else 0
+                        )
+
                         # Metrics
                         col1, col2, col3 = st.columns([1, 1, 1])
-                        unique_assays = len(data_meta_df["ASSAY"].unique())
-                        delta_assays = (
-                            unique_assays - comp_assay_count
-                            if comp_assay_count is not None
+                        delta_users = (
+                            unique_users_count - comp_user_count
+                            if comp_user_count is not None
                             else None
                         )
                         col1.metric(
-                            "Number of Unique Assays", unique_assays, delta=delta_assays
+                            "Total Unique Users", unique_users_count, delta=delta_users
                         )
-                        col2.metric("", "")
-                        col3.metric("Avg. ", 3)
+                        col2.metric(
+                            "Average Downloaders Per Project",
+                            f"{avg_users_per_project:.1f}",
+                        )
+                        col3.metric(
+                            "Avg. Download Size Per User",
+                            f"{(total_downloads_gb / unique_users_count) if unique_users_count else 0:,.2f} GB",
+                        )
 
-                        # What are assays being downloaded?
+                        # Plot of user network
+                        st.info(
+                            "The interactive network chart can be slow in Snowflake for broad filters. "
+                            "If it stalls, reduce the date range or selected projects."
+                        )
+                        col1, col2, col3 = st.columns([4, 1, 1])
+                        with col1:
+                            plot_network(unique_users_df)
+                        with col2:
+                            network_legend()
+
+                        # How many unique users are downloading data for each project monthly?
+                        st.plotly_chart(plot_unique_users_monthly(unique_users_df))
+
+                    # Cumulative Data Growth ---------------------------------------------------------------#
+                    st.header("Cumulative Data Growth")
+                    st.subheader("Data Portal Growth Over Time")
+                    cumulative_growth_df = get_data_from_snowflake(
+                        query_file_metadata_for_growth(project_ids)
+                    )
+                    if cumulative_growth_df.empty:
+                        st.warning(
+                            "No cumulative data growth data available for the selected projects."
+                        )
+                    else:
                         st.plotly_chart(
-                            plot_resource_downloads(
-                                data_meta_df,
-                                resource_column="ASSAY",
-                                color=ORANGE,
-                                title="Assays Being Downloaded",
+                            plot_cumulative_data_growth(
+                                cumulative_growth_df, width=plot_width
                             )
                         )
 
-                        # What are resources being downloaded?
-                        st.plotly_chart(
-                            plot_resource_downloads(
-                                data_meta_df,
-                                resource_column="RESOURCE_TYPE",
-                                color=PURPLE,
-                                title="Resources Being Downloaded",
-                            )
+                    # Google Analytics ---------------------------------------------------------------#
+                    # Google analytics measurements go here for now
+                    # 1. Web views --
+                    # a) Mostly corresponds with top projects by numbers of unique downloaders, but interesting when it doesn't
+                    # b) Can suggest projects that still have influence/value for non-downloader users such as patients / patient advocates
+                    # c) Potentially a leading indicator of interest and collaboration for *un-released* projects
+                    # st.header("Google Analytics")
+                    # st.subheader("Total Page Views for synapse.org project pages")
+                    # pageviews_df = get_total_page_views(project_ids, start_date, end_date)
+                    # pageviews_df = pageviews_df.merge(filtered_project_meta[['PROJECT_ID', 'PROJECT_NAME']], on='PROJECT_ID', how='left')
+                    # st.table(pageviews_df)
+                    # st.plotly_chart(plot_project_pageviews(pageviews_df))
+
+                    # Initiative Data Metrics ---------------------------------------------------------------#
+                    st.header("Initiative Data Metrics")
+
+                    # Show info box about scope
+                    scope_description = (
+                        "Open Proposal Program only"
+                        if open_proposal_only
+                        else (
+                            f"{len(selected_initiatives)} initiative(s)"
+                            if selected_initiatives
+                            else "All initiatives"
                         )
-
-            # User Network -----------------------------------------------------------------------#
-            st.header("Users Network")
-            if project_ids:
-                unique_users_df = get_data_from_snowflake(
-                    query_unique_users(project_ids, start_date, end_date)
-                )
-                if unique_users_df.empty:
-                    st.warning(
-                        "No unique user data available for the selected projects."
                     )
-                else:
-                    unique_users_count = unique_users_df["USER_ID"].nunique()
-                    avg_users_per_project = (
-                        unique_users_count / len(project_downloads_df)
-                        if len(project_downloads_df) > 0
-                        else 0
-                    )
-
-                    # Metrics
-                    col1, col2, col3 = st.columns([1, 1, 1])
-                    delta_users = (
-                        unique_users_count - comp_user_count
-                        if comp_user_count is not None
-                        else None
-                    )
-                    col1.metric(
-                        "Total Unique Users", unique_users_count, delta=delta_users
-                    )
-                    col2.metric(
-                        "Average Downloaders Per Project",
-                        f"{avg_users_per_project:.1f}",
-                    )
-                    col3.metric(
-                        "Avg. Download Size Per User",
-                        f"{(total_downloads_gb / unique_users_count) if unique_users_count else 0:,.2f} GB",
-                    )
-
-                    # Plot of user network
                     st.info(
-                        "The interactive network chart can be slow in Snowflake for broad filters. "
-                        "If it stalls, reduce the date range or selected projects."
+                        f"📊 **Current Scope:** {scope_description} | **Projects:** {len(project_ids)}"
                     )
-                    col1, col2, col3 = st.columns([4, 1, 1])
-                    with col1:
-                        plot_network(unique_users_df)
-                    with col2:
-                        network_legend()
 
-                    # How many unique users are downloading data for each project monthly?
-                    st.plotly_chart(plot_unique_users_monthly(unique_users_df))
+                    # Total Data Size
+                    st.subheader("Total Data Size")
+                    with st.expander("ℹ️ Metric Definition"):
+                        st.markdown("""
+                        **Total Data Size** aggregates the content size of all files across the scoped projects.
+                        - **Size aggregation**: Sum of all file content_size values
+                        - **Units**: Displayed in TB (terabytes) with 1 decimal place
+                        - **Scope**: Respects both Initiative filter and Open Proposal toggle
+                        """)
 
-                # Cumulative Data Growth ---------------------------------------------------------------#
-                st.header("Cumulative Data Growth")
-                st.subheader("Data Portal Growth Over Time")
-                cumulative_growth_df = get_data_from_snowflake(
-                    query_file_metadata_for_growth(project_ids)
-                )
-                if cumulative_growth_df.empty:
-                    st.warning(
-                        "No cumulative data growth data available for the selected projects."
+                    total_size_df = get_data_from_snowflake(
+                        query_total_data_size_by_initiative(project_ids)
                     )
+                    if (
+                        not total_size_df.empty
+                        and total_size_df["TOTAL_CONTENT_SIZE"].iloc[0] is not None
+                    ):
+                        total_size_bytes = total_size_df["TOTAL_CONTENT_SIZE"].iloc[0]
+                        total_file_count = total_size_df["TOTAL_FILE_COUNT"].iloc[0]
+                        size_value, size_unit = format_size_metric(total_size_bytes)
+
+                        col1, col2, col3 = st.columns([1, 1, 1])
+                        with col1:
+                            st.metric(
+                                label="Total Data Size",
+                                value=f"{size_value:.1f} {size_unit}",
+                                help=f"Exact size: {total_size_bytes:,} bytes",
+                            )
+                        with col2:
+                            st.metric(
+                                label="Total Files",
+                                value=f"{total_file_count:,}",
+                                help="Number of unique files across all scoped projects",
+                            )
+                        with col3:
+                            avg_file_size_mb = (
+                                (total_size_bytes / total_file_count / (1024**2))
+                                if total_file_count > 0
+                                else 0
+                            )
+                            st.metric(
+                                label="Avg File Size",
+                                value=f"{avg_file_size_mb:.1f} MB",
+                                help="Average size per file",
+                            )
+                    else:
+                        st.warning(
+                            "No data size information available for the selected projects."
+                        )
+
+                    # Top 5 Data Types by Size
+                    st.subheader("Top 5 Data Types by Size")
+                    with st.expander("ℹ️ Metric Definition"):
+                        st.markdown("""
+                        **Top Data Types** shows the 5 largest data types (by total size) across scoped projects.
+                        - **Data type**: Derived from file 'assay' annotation
+                        - **Ranking**: Sorted by total size descending; ties broken by data type name (ascending)
+                        - **Limit**: Exactly 5 rows (or fewer if <5 types exist)
+                        - **Scope**: Respects both Initiative filter and Open Proposal toggle
+                        """)
+
+                    top_data_types_df = get_data_from_snowflake(
+                        query_top_data_types_by_size(project_ids, limit=5)
+                    )
+                    if not top_data_types_df.empty:
+                        st.plotly_chart(
+                            plot_data_type_bar_chart(
+                                top_data_types_df,
+                                title="Top 5 Data Types by Size",
+                                width=plot_width,
+                                color=TEAL,
+                            )
+                        )
+
+                        # Display table
+                        st.markdown("**Detailed Breakdown:**")
+                        display_table = create_data_type_table(top_data_types_df)
+                        st.table(display_table)
+                    else:
+                        st.warning(
+                            "No data type information available for the selected projects."
+                        )
+
+                    # Released Data Only - Data Size by Type
+                    st.subheader("Released Data Only - Data Size by Type")
+                    with st.expander("ℹ️ Metric Definition"):
+                        st.markdown("""
+                        **Released Data** filters to only projects with released data status before grouping by data type.
+                        - **Released statuses**: 'Available', 'Partially Available', 'Rolling Release'
+                        - **Data type**: Derived from file 'assay' annotation
+                        - **Ranking**: Sorted by total size descending; ties broken by data type name (ascending)
+                        - **Limit**: Exactly 5 rows (or fewer if <5 types exist)
+                        - **Scope**: Respects both Initiative filter and Open Proposal toggle
+                        """)
+
+                    released_statuses = [
+                        "Available",
+                        "Partially Available",
+                        "Rolling Release",
+                    ]
+                    released_data_df = get_data_from_snowflake(
+                        query_released_data_by_type(project_ids, released_statuses, limit=5)
+                    )
+                    if not released_data_df.empty:
+                        st.plotly_chart(
+                            plot_data_type_bar_chart(
+                                released_data_df,
+                                title="Top 5 Data Types (Released Projects Only)",
+                                width=plot_width,
+                                color=GREEN,
+                            )
+                        )
+
+                        # Display table
+                        st.markdown("**Detailed Breakdown:**")
+                        display_table = create_data_type_table(released_data_df)
+                        st.table(display_table)
+                    else:
+                        st.warning(
+                            "No released data available for the selected projects, or no data type information available."
+                        )
+
+            with tab2:
+                st.header("Data Lifecycle")
+                st.subheader("Upload Age & Download Recency — Released Projects Only")
+
+                # S3 tier estimate covers all NF portal data regardless of sidebar filters
+                st.subheader("Estimated S3 Intelligent Tiering Distribution")
+                tier_df = get_data_from_snowflake(query_s3_tier_all_portal())
+                if not tier_df.empty:
+                    st.plotly_chart(plot_s3_tier_estimate(tier_df))
+
+                released_statuses = ["Available", "Partially Available", "Rolling Release"]
+                eol_project_ids = filtered_project_meta[
+                    filtered_project_meta["DATA_STATUS"].isin(released_statuses)
+                ]["PROJECT_ID"].tolist()
+
+                if not eol_project_ids:
+                    st.warning("No released projects in the current selection.")
                 else:
-                    st.plotly_chart(
-                        plot_cumulative_data_growth(
-                            cumulative_growth_df, width=plot_width
+                    eol_df = get_data_from_snowflake(query_file_eol_analysis(eol_project_ids))
+
+                    if eol_df.empty:
+                        st.warning("No file lifecycle data available for the selected projects.")
+                    else:
+                        eol_df = eol_df.merge(
+                            filtered_project_meta[["PROJECT_ID", "PROJECT_NAME"]],
+                            on="PROJECT_ID", how="left"
                         )
-                    )
 
-                # Google Analytics ---------------------------------------------------------------#
-                # Google analytics measurements go here for now
-                # 1. Web views --
-                # a) Mostly corresponds with top projects by numbers of unique downloaders, but interesting when it doesn't
-                # b) Can suggest projects that still have influence/value for non-downloader users such as patients / patient advocates
-                # c) Potentially a leading indicator of interest and collaboration for *un-released* projects
-                # st.header("Google Analytics")
-                # st.subheader("Total Page Views for synapse.org project pages")
-                # pageviews_df = get_total_page_views(project_ids, start_date, end_date)
-                # pageviews_df = pageviews_df.merge(filtered_project_meta[['PROJECT_ID', 'PROJECT_NAME']], on='PROJECT_ID', how='left')
-                # st.table(pageviews_df)
-                # st.plotly_chart(plot_project_pageviews(pageviews_df))
-
-                # Initiative Data Metrics ---------------------------------------------------------------#
-                st.header("Initiative Data Metrics")
-
-                # Show info box about scope
-                scope_description = (
-                    "Open Proposal Program only"
-                    if open_proposal_only
-                    else (
-                        f"{len(selected_initiatives)} initiative(s)"
-                        if selected_initiatives
-                        else "All initiatives"
-                    )
-                )
-                st.info(
-                    f"📊 **Current Scope:** {scope_description} | **Projects:** {len(project_ids)}"
-                )
-
-                # Total Data Size
-                st.subheader("Total Data Size")
-                with st.expander("ℹ️ Metric Definition"):
-                    st.markdown("""
-                    **Total Data Size** aggregates the content size of all files across the scoped projects.
-                    - **Size aggregation**: Sum of all file content_size values
-                    - **Units**: Displayed in TB (terabytes) with 1 decimal place
-                    - **Scope**: Respects both Initiative filter and Open Proposal toggle
-                    """)
-
-                total_size_df = get_data_from_snowflake(
-                    query_total_data_size_by_initiative(project_ids)
-                )
-                if (
-                    not total_size_df.empty
-                    and total_size_df["TOTAL_CONTENT_SIZE"].iloc[0] is not None
-                ):
-                    total_size_bytes = total_size_df["TOTAL_CONTENT_SIZE"].iloc[0]
-                    total_file_count = total_size_df["TOTAL_FILE_COUNT"].iloc[0]
-                    size_value, size_unit = format_size_metric(total_size_bytes)
-
-                    col1, col2, col3 = st.columns([1, 1, 1])
-                    with col1:
-                        st.metric(
-                            label="Total Data Size",
-                            value=f"{size_value:.1f} {size_unit}",
-                            help=f"Exact size: {total_size_bytes:,} bytes",
+                        st.info(
+                            "⚠️ **Data caveat:** Snowflake download records only go back to 2022-01-01. "
+                            "Files with no download record that were uploaded **before 2022** may have been "
+                            "downloaded prior to that date — they are marked below as 'no record since 2022' "
+                            "rather than 'never downloaded'."
                         )
-                    with col2:
-                        st.metric(
-                            label="Total Files",
-                            value=f"{total_file_count:,}",
-                            help="Number of unique files across all scoped projects",
+
+                        upload_eol_days = 10 * 365
+                        download_stale_days = 5 * 365
+                        data_cutoff = pd.Timestamp("2022-01-01")
+
+                        eol_df["UPLOAD_DATE_DT"] = pd.to_datetime(eol_df["UPLOAD_DATE"])
+
+                        total_files = len(eol_df)
+
+                        # Split "no download record" into pre/post data cutoff
+                        no_record = eol_df["LAST_DOWNLOAD_DATE"].isna()
+                        uploaded_post_cutoff = eol_df["UPLOAD_DATE_DT"] >= data_cutoff
+                        truly_never_dl = (no_record & uploaded_post_cutoff).sum()
+                        no_record_pre2022 = (no_record & ~uploaded_post_cutoff).sum()
+
+                        stale_files = eol_df[
+                            eol_df["DAYS_SINCE_LAST_DOWNLOAD"].notna() &
+                            (eol_df["DAYS_SINCE_LAST_DOWNLOAD"] > download_stale_days)
+                        ]
+                        stale_count = len(stale_files)
+
+                        eol_candidates_df = eol_df[
+                            (eol_df["DAYS_SINCE_UPLOAD"] > upload_eol_days) &
+                            (
+                                eol_df["LAST_DOWNLOAD_DATE"].isna() |
+                                (eol_df["DAYS_SINCE_LAST_DOWNLOAD"] > download_stale_days)
+                            )
+                        ]
+                        candidate_files = len(eol_candidates_df)
+                        candidate_size_tb = convert_to_tb(eol_candidates_df["CONTENT_SIZE"].sum())
+
+                        col1, col2, col3, col4 = st.columns(4)
+                        col1.metric("Total Unique Files", f"{total_files:,}")
+                        col2.metric("No Download Record (post-2022 uploads)", f"{truly_never_dl:,}")
+                        col3.metric("Deletion Candidates (Files)", f"{candidate_files:,}")
+                        col4.metric("Deletion Candidates (Storage)", f"{candidate_size_tb:,.2f} TB")
+
+                        st.markdown(
+                            f"""
+                            **{truly_never_dl:,}** files uploaded after 2022-01-01 have **no download record** — these are confidently never downloaded.
+
+                            **{no_record_pre2022:,}** files uploaded before 2022-01-01 have no download record since 2022 — downloads prior to that date are unknown.
+
+                            **{stale_count:,}** files have been downloaded at some point but not accessed in the last 5 years.
+                            Combined storage: **{convert_to_gb(stale_files["CONTENT_SIZE"].sum()):,.1f} GB**.
+                            """
                         )
-                    with col3:
-                        avg_file_size_mb = (
-                            (total_size_bytes / total_file_count / (1024**2))
-                            if total_file_count > 0
-                            else 0
-                        )
-                        st.metric(
-                            label="Avg File Size",
-                            value=f"{avg_file_size_mb:.1f} MB",
-                            help="Average size per file",
-                        )
-                else:
-                    st.warning(
-                        "No data size information available for the selected projects."
-                    )
 
-                # Top 5 Data Types by Size
-                st.subheader("Top 5 Data Types by Size")
-                with st.expander("ℹ️ Metric Definition"):
-                    st.markdown("""
-                    **Top Data Types** shows the 5 largest data types (by total size) across scoped projects.
-                    - **Data type**: Derived from file 'assay' annotation
-                    - **Ranking**: Sorted by total size descending; ties broken by data type name (ascending)
-                    - **Limit**: Exactly 5 rows (or fewer if <5 types exist)
-                    - **Scope**: Respects both Initiative filter and Open Proposal toggle
-                    """)
-
-                top_data_types_df = get_data_from_snowflake(
-                    query_top_data_types_by_size(project_ids, limit=5)
-                )
-                if not top_data_types_df.empty:
-                    st.plotly_chart(
-                        plot_data_type_bar_chart(
-                            top_data_types_df,
-                            title="Top 5 Data Types by Size",
-                            width=plot_width,
-                            color=TEAL,
-                        )
-                    )
-
-                    # Display table
-                    st.markdown("**Detailed Breakdown:**")
-                    display_table = create_data_type_table(top_data_types_df)
-                    st.table(display_table)
-                else:
-                    st.warning(
-                        "No data type information available for the selected projects."
-                    )
-
-                # Released Data Only - Data Size by Type
-                st.subheader("Released Data Only - Data Size by Type")
-                with st.expander("ℹ️ Metric Definition"):
-                    st.markdown("""
-                    **Released Data** filters to only projects with released data status before grouping by data type.
-                    - **Released statuses**: 'Available', 'Partially Available', 'Rolling Release'
-                    - **Data type**: Derived from file 'assay' annotation
-                    - **Ranking**: Sorted by total size descending; ties broken by data type name (ascending)
-                    - **Limit**: Exactly 5 rows (or fewer if <5 types exist)
-                    - **Scope**: Respects both Initiative filter and Open Proposal toggle
-                    """)
-
-                released_statuses = [
-                    "Available",
-                    "Partially Available",
-                    "Rolling Release",
-                ]
-                released_data_df = get_data_from_snowflake(
-                    query_released_data_by_type(project_ids, released_statuses, limit=5)
-                )
-                if not released_data_df.empty:
-                    st.plotly_chart(
-                        plot_data_type_bar_chart(
-                            released_data_df,
-                            title="Top 5 Data Types (Released Projects Only)",
-                            width=plot_width,
-                            color=GREEN,
-                        )
-                    )
-
-                    # Display table
-                    st.markdown("**Detailed Breakdown:**")
-                    display_table = create_data_type_table(released_data_df)
-                    st.table(display_table)
-                else:
-                    st.warning(
-                        "No released data available for the selected projects, or no data type information available."
-                    )
+                        st.plotly_chart(plot_eol_never_downloaded(
+                            eol_candidates_df[eol_candidates_df["LAST_DOWNLOAD_DATE"].isna()],
+                            width=plot_width
+                        ))
+                        st.plotly_chart(plot_eol_stale_downloads(
+                            eol_candidates_df[eol_candidates_df["LAST_DOWNLOAD_DATE"].notna()],
+                            width=plot_width
+                        ))
+                        st.plotly_chart(plot_eol_scatter(eol_df, upload_threshold=10.0, download_threshold=5.0, width=plot_width))
+                        st.plotly_chart(plot_never_downloaded_by_project(eol_df, width=plot_width))
 
     else:
         st.write("No projects match filters.")

--- a/sage/nf/streamlit/nf_usage_metrics/toolkit/queries.py
+++ b/sage/nf/streamlit/nf_usage_metrics/toolkit/queries.py
@@ -687,3 +687,247 @@ def query_released_data_by_type(project_ids, released_statuses=None, limit=5):
         data_type ASC
     LIMIT {limit};
     """
+
+
+def query_table_query_counts(project_id=26338068, start_date='2022-01-01', excluded_users=STAFF_USERIDS):
+    """Return query counts for all tables and views within a specific project since start_date,
+    excluding internal Sage/DCC staff users. Uses access_event with the table query async start
+    endpoint as the signal for a table query."""
+
+    return f"""
+    WITH project_tables AS (
+        SELECT
+            nl.id AS entity_id,
+            nl.name AS entity_name,
+            nl.node_type
+        FROM
+            synapse_data_warehouse.synapse.node_latest nl
+        WHERE
+            nl.project_id = {project_id}
+            AND nl.node_type IN ('table', 'entityview', 'submissionview', 'dataset', 'datasetcollection', 'materializedview')
+    )
+    SELECT
+        pt.entity_id,
+        pt.entity_name,
+        pt.node_type,
+        COUNT(*) AS query_count
+    FROM
+        project_tables pt
+    JOIN
+        synapse_data_warehouse.synapse_event.access_event ae
+    ON
+        ae.entity_id = pt.entity_id
+    WHERE
+        ae.normalized_method_signature = 'POST /entity/#/table/query/async/start'
+        AND ae.record_date >= '{start_date}'
+        AND ae.user_id NOT IN ({','.join(map(str, excluded_users))})
+    GROUP BY
+        pt.entity_id,
+        pt.entity_name,
+        pt.node_type
+    ORDER BY
+        query_count DESC;
+    """
+
+
+def query_s3_tier_all_portal():
+    """Estimate S3 Intelligent Tiering storage distribution across the entire NF data portal.
+
+    Covers all projects in the portal view regardless of funder, data status, or sidebar filters.
+    Uses last download date (any user) to assign tiers; falls back to upload date for never-downloaded files.
+    All downloads are counted because any S3 access resets the tier, regardless of who triggered it.
+
+    Tiers:
+        Frequent Access:      <= 30 days inactive
+        Infrequent Access:    31–90 days
+        Archive Access:       91–180 days
+        Deep Archive Access:  > 180 days
+    """
+    return f"""
+    WITH portal_projects AS (
+        SELECT CAST(scopes.value AS INTEGER) AS project_id
+        FROM synapse_data_warehouse.synapse.node_latest,
+             LATERAL FLATTEN(input => node_latest.scope_ids) scopes
+        WHERE id = {PROJECT_VIEW_ID}
+    ),
+    project_files AS (
+        SELECT
+            nl.project_id,
+            nl.file_handle_id,
+            MIN(nl.created_on) AS upload_date
+        FROM synapse_data_warehouse.synapse.node_latest nl
+        JOIN portal_projects pp ON nl.project_id = pp.project_id
+        WHERE nl.file_handle_id IS NOT NULL
+        GROUP BY nl.project_id, nl.file_handle_id
+    ),
+    file_sizes AS (
+        SELECT id, content_size
+        FROM synapse_data_warehouse.synapse.file_latest
+        WHERE content_size IS NOT NULL AND content_size > 0
+    ),
+    file_downloads AS (
+        SELECT
+            file_handle_id,
+            MAX(record_date) AS last_download_date
+        FROM synapse_data_warehouse.synapse_event.objectdownload_event
+        GROUP BY file_handle_id
+    ),
+    file_activity AS (
+        SELECT
+            pf.file_handle_id,
+            fs.content_size,
+            COALESCE(
+                DATEDIFF('day', fd.last_download_date, CURRENT_DATE),
+                DATEDIFF('day', pf.upload_date, CURRENT_DATE)
+            ) AS days_inactive
+        FROM project_files pf
+        JOIN file_sizes fs ON fs.id = pf.file_handle_id
+        LEFT JOIN file_downloads fd ON fd.file_handle_id = pf.file_handle_id
+    )
+    SELECT
+        CASE
+            WHEN days_inactive <= 30  THEN 'Frequent Access'
+            WHEN days_inactive <= 90  THEN 'Infrequent Access'
+            WHEN days_inactive <= 180 THEN 'Archive Access'
+            ELSE                           'Deep Archive Access'
+        END AS tier,
+        SUM(content_size) / POWER(1024, 4) AS size_tb
+    FROM file_activity
+    GROUP BY tier
+    ORDER BY tier;
+    """
+
+
+def query_deep_archive_examples(n=20):
+    """Return a sample of files estimated to be in the S3 Deep Archive tier (inactive >180 days).
+
+    All downloads are counted (including staff) since any S3 access resets the tier.
+    Returns node IDs so files can be located in Synapse, along with size and last activity date.
+    """
+    return f"""
+    WITH portal_projects AS (
+        SELECT CAST(scopes.value AS INTEGER) AS project_id
+        FROM synapse_data_warehouse.synapse.node_latest,
+             LATERAL FLATTEN(input => node_latest.scope_ids) scopes
+        WHERE id = {PROJECT_VIEW_ID}
+    ),
+    project_files AS (
+        SELECT
+            nl.id AS node_id,
+            nl.project_id,
+            nl.file_handle_id,
+            nl.created_on AS upload_date
+        FROM synapse_data_warehouse.synapse.node_latest nl
+        JOIN portal_projects pp ON nl.project_id = pp.project_id
+        WHERE nl.file_handle_id IS NOT NULL
+          AND nl.node_type = 'file'
+    ),
+    file_sizes AS (
+        SELECT id, content_size
+        FROM synapse_data_warehouse.synapse.file_latest
+        WHERE content_size IS NOT NULL AND content_size > 0
+    ),
+    file_downloads AS (
+        SELECT
+            file_handle_id,
+            MAX(record_date) AS last_download_date
+        FROM synapse_data_warehouse.synapse_event.objectdownload_event
+        GROUP BY file_handle_id
+    )
+    SELECT
+        'syn' || pf.node_id AS synapse_id,
+        pf.project_id,
+        fs.content_size / (1024 * 1024) AS size_mb,
+        pf.upload_date::DATE AS upload_date,
+        fd.last_download_date::DATE AS last_download_date,
+        COALESCE(
+            DATEDIFF('day', fd.last_download_date, CURRENT_DATE),
+            DATEDIFF('day', pf.upload_date, CURRENT_DATE)
+        ) AS days_inactive
+    FROM project_files pf
+    JOIN file_sizes fs ON fs.id = pf.file_handle_id
+    LEFT JOIN file_downloads fd ON fd.file_handle_id = pf.file_handle_id
+    WHERE COALESCE(
+            DATEDIFF('day', fd.last_download_date, CURRENT_DATE),
+            DATEDIFF('day', pf.upload_date, CURRENT_DATE)
+          ) > 180
+      AND fs.content_size >= 10 * 1024 * 1024
+    ORDER BY RANDOM()
+    LIMIT {n};
+    """
+
+
+def query_file_eol_analysis(project_ids, excluded_users=STAFF_USERIDS):
+    """Return per-file upload date and last download date for end-of-life analysis.
+
+    Returns one row per unique (project_id, file_handle_id) pair with:
+    - upload_date: earliest created_on for that file handle in the project
+    - content_size: file size in bytes
+    - last_download_date: most recent external download (NULL if never downloaded)
+    - download_count: total external download events (0 if never downloaded)
+    - days_since_upload / days_since_last_download: computed age fields
+    """
+
+    project_list = ', '.join(f"'{id}'" for id in project_ids)
+
+    return f"""
+    WITH project_files AS (
+        SELECT
+            nl.project_id,
+            nl.file_handle_id,
+            MIN(nl.created_on) AS upload_date
+        FROM
+            synapse_data_warehouse.synapse.node_latest nl
+        WHERE
+            nl.project_id IN ({project_list})
+            AND nl.file_handle_id IS NOT NULL
+        GROUP BY
+            nl.project_id, nl.file_handle_id
+    ),
+    file_sizes AS (
+        SELECT
+            id,
+            content_size
+        FROM
+            synapse_data_warehouse.synapse.file_latest
+        WHERE
+            content_size IS NOT NULL
+            AND content_size > 0
+    ),
+    file_downloads AS (
+        SELECT
+            file_handle_id,
+            MAX(record_date) AS last_download_date,
+            COUNT(*) AS download_count
+        FROM
+            synapse_data_warehouse.synapse_event.objectdownload_event
+        WHERE
+            project_id IN ({project_list})
+            AND user_id NOT IN ({','.join(map(str, excluded_users))})
+        GROUP BY
+            file_handle_id
+    )
+    SELECT
+        pf.project_id,
+        pf.file_handle_id,
+        pf.upload_date,
+        fs.content_size,
+        fd.last_download_date,
+        COALESCE(fd.download_count, 0) AS download_count,
+        DATEDIFF('day', pf.upload_date, CURRENT_DATE) AS days_since_upload,
+        CASE
+            WHEN fd.last_download_date IS NOT NULL
+            THEN DATEDIFF('day', fd.last_download_date, CURRENT_DATE)
+            ELSE NULL
+        END AS days_since_last_download
+    FROM
+        project_files pf
+    JOIN
+        file_sizes fs ON fs.id = pf.file_handle_id
+    LEFT JOIN
+        file_downloads fd ON fd.file_handle_id = pf.file_handle_id
+    ORDER BY
+        pf.upload_date;
+    """
+
+

--- a/sage/nf/streamlit/nf_usage_metrics/toolkit/widgets.py
+++ b/sage/nf/streamlit/nf_usage_metrics/toolkit/widgets.py
@@ -997,3 +997,399 @@ def format_size_metric(bytes_value):
         return bytes_value / (1024**2), "MB"
     else:
         return bytes_value, "Bytes"
+
+
+def plot_upload_age_histogram(df, width=1400, height=500):
+    """Histogram of files by upload age (years since upload_date).
+
+    Pre-aggregates into 0.5-year bins server-side to keep the figure small.
+
+    Args:
+        df: DataFrame with columns DAYS_SINCE_UPLOAD and PROJECT_ID (and optionally PROJECT_NAME)
+    """
+    if df.empty:
+        return go.Figure()
+
+    years = df['DAYS_SINCE_UPLOAD'] / 365.25
+    bins = pd.cut(years, bins=30)
+    counts = bins.value_counts().sort_index()
+    bin_labels = [f"{iv.left:.1f}–{iv.right:.1f}" for iv in counts.index]
+
+    fig = go.Figure(go.Bar(
+        x=bin_labels,
+        y=counts.values,
+        marker_color=PORTAL_BLUE,
+        opacity=0.85,
+    ))
+    fig.update_layout(
+        title='Distribution of Files by Upload Age',
+        xaxis_title='Years Since Upload',
+        yaxis_title='Number of Files',
+        width=width,
+        height=height,
+        xaxis_tickangle=-45,
+    )
+    return fig
+
+
+def plot_download_recency_histogram(df, width=1400, height=500):
+    """Histogram of time since last download for files that have been downloaded at least once.
+
+    Pre-aggregates into bins server-side to keep the figure small.
+
+    Args:
+        df: DataFrame with column DAYS_SINCE_LAST_DOWNLOAD (NaN = never downloaded)
+    """
+    if df.empty:
+        return go.Figure()
+
+    downloaded = df.dropna(subset=['DAYS_SINCE_LAST_DOWNLOAD'])
+    if downloaded.empty:
+        fig = go.Figure()
+        fig.update_layout(title='No files have been downloaded yet.')
+        return fig
+
+    years = downloaded['DAYS_SINCE_LAST_DOWNLOAD'] / 365.25
+    bins = pd.cut(years, bins=30)
+    counts = bins.value_counts().sort_index()
+    bin_labels = [f"{iv.left:.1f}–{iv.right:.1f}" for iv in counts.index]
+
+    fig = go.Figure(go.Bar(
+        x=bin_labels,
+        y=counts.values,
+        marker_color=PORTAL_BLUE,
+        opacity=0.85,
+    ))
+    fig.update_layout(
+        title='Download Recency: Time Since Last External Download (Downloaded Files Only)',
+        xaxis_title='Years Since Last Download',
+        yaxis_title='Number of Files',
+        width=width,
+        height=height,
+        xaxis_tickangle=-45,
+    )
+    return fig
+
+
+def plot_never_downloaded_by_project(df, width=1400, height=600):
+    """Per-project grouped bar chart showing count and storage of never-downloaded vs downloaded files.
+
+    Args:
+        df: DataFrame with columns PROJECT_ID, PROJECT_NAME (optional), CONTENT_SIZE,
+            DAYS_SINCE_LAST_DOWNLOAD (NaN = never downloaded)
+    """
+    if df.empty:
+        return go.Figure()
+
+    df = df.copy()
+    df['downloaded'] = df['DAYS_SINCE_LAST_DOWNLOAD'].notna()
+    label_col = 'PROJECT_NAME' if 'PROJECT_NAME' in df.columns else 'PROJECT_ID'
+
+    summary = (
+        df.groupby([label_col, 'downloaded'])
+        .agg(file_count=('FILE_HANDLE_ID', 'count'),
+             total_size_gb=('CONTENT_SIZE', lambda x: x.sum() / 1e9))
+        .reset_index()
+    )
+    summary['status'] = summary['downloaded'].map({True: 'Downloaded', False: 'Never Downloaded'})
+
+    # Truncate long project names
+    summary['short_name'] = summary[label_col].apply(
+        lambda x: ' '.join(str(x).split()[:4]) + ('…' if len(str(x).split()) > 4 else '')
+    )
+
+    fig = go.Figure()
+    colors = {'Downloaded': PORTAL_BLUE, 'Never Downloaded': ORANGE}
+
+    for status in ['Downloaded', 'Never Downloaded']:
+        sub = summary[summary['status'] == status]
+        fig.add_trace(go.Bar(
+            name=status,
+            x=sub['short_name'],
+            y=sub['total_size_gb'],
+            marker_color=colors[status],
+            customdata=sub[['file_count', label_col]].values,
+            hovertemplate=(
+                '<b>%{customdata[1]}</b><br>'
+                'Storage: %{y:.1f} GB<br>'
+                'Files: %{customdata[0]:,}<extra></extra>'
+            )
+        ))
+
+    fig.update_layout(
+        barmode='group',
+        title='Storage Never Downloaded vs Downloaded, by Project',
+        xaxis_title='Project',
+        yaxis_title='Storage (GB)',
+        xaxis_tickangle=-40,
+        width=width,
+        height=height,
+        legend=dict(x=1.02, y=1),
+    )
+    return fig
+
+
+def plot_eol_scatter(df, upload_threshold=8.0, download_threshold=2.0, width=1400, height=700):
+    """Scatter plot: upload age (x) vs years since last download (y).
+
+    Files never downloaded are plotted along y=0 as hollow markers.
+    Separate threshold lines on each axis mark the EOL boundary.
+
+    Args:
+        df: DataFrame with DAYS_SINCE_UPLOAD, DAYS_SINCE_LAST_DOWNLOAD,
+            CONTENT_SIZE, PROJECT_ID, PROJECT_NAME (optional)
+        upload_threshold: years since upload before a file is considered old (x-axis line)
+        download_threshold: years since last download before a file is considered stale (y-axis line)
+    """
+    if df.empty:
+        return go.Figure()
+
+    df = df.copy()
+    label_col = 'PROJECT_NAME' if 'PROJECT_NAME' in df.columns else 'PROJECT_ID'
+    df['years_since_upload'] = df['DAYS_SINCE_UPLOAD'] / 365.25
+    df['years_since_download'] = df['DAYS_SINCE_LAST_DOWNLOAD'] / 365.25
+    df['size_gb'] = df['CONTENT_SIZE'] / 1e9
+    df['short_name'] = df[label_col].apply(
+        lambda x: ' '.join(str(x).split()[:4]) + ('…' if len(str(x).split()) > 4 else '')
+    )
+
+    # Filter to files >= 10 MB to reduce noise and improve rendering performance
+    df = df[df['CONTENT_SIZE'] >= 10 * 1024 * 1024].copy()
+
+    never_dl = df[df['DAYS_SINCE_LAST_DOWNLOAD'].isna()].copy()
+    ever_dl = df[df['DAYS_SINCE_LAST_DOWNLOAD'].notna()].copy()
+
+    fig = go.Figure()
+
+    max_x = max(df['years_since_upload'].max() * 1.05, upload_threshold + 0.5)
+    max_y = ever_dl['years_since_download'].max() * 1.05 if not ever_dl.empty else download_threshold + 0.5
+
+    # Vertical line: upload age threshold (8 yrs)
+    fig.add_shape(type='line', x0=upload_threshold, x1=upload_threshold, y0=0, y1=max_y,
+                  line=dict(color='rgba(180,0,0,0.4)', width=1.5, dash='dash'))
+    # Horizontal line: download recency threshold (2 yrs)
+    fig.add_shape(type='line', x0=0, x1=max_x, y0=download_threshold, y1=download_threshold,
+                  line=dict(color='rgba(180,0,0,0.4)', width=1.5, dash='dash'))
+
+    # Quadrant label: EOL candidates (upper-right: old upload AND stale download)
+    fig.add_annotation(
+        x=max_x * 0.97, y=max_y * 0.97,
+        text=f'<b>EOL candidates</b><br>Upload >{upload_threshold:.0f} yr & not downloaded in >{download_threshold:.0f} yr',
+        showarrow=False,
+        font=dict(color='rgba(180,0,0,0.7)', size=11),
+        align='right',
+        xanchor='right',
+    )
+
+    if not ever_dl.empty:
+        fig.add_trace(go.Scatter(
+            x=ever_dl['years_since_upload'],
+            y=ever_dl['years_since_download'],
+            mode='markers',
+            name='Downloaded ≥1×',
+            marker=dict(
+                size=ever_dl['size_gb'].clip(lower=0.5).apply(lambda s: min(5 + s * 0.3, 25)),
+                color=PORTAL_BLUE,
+                opacity=0.6,
+                line=dict(width=0.5, color='white')
+            ),
+            customdata=ever_dl[['short_name', 'DOWNLOAD_COUNT', 'size_gb']].values,
+            hovertemplate=(
+                '<b>%{customdata[0]}</b><br>'
+                'Upload age: %{x:.1f} yr<br>'
+                'Since last download: %{y:.1f} yr<br>'
+                'Downloads: %{customdata[1]:,}<br>'
+                'Size: %{customdata[2]:.2f} GB<extra></extra>'
+            )
+        ))
+
+    if not never_dl.empty:
+        fig.add_trace(go.Scatter(
+            x=never_dl['years_since_upload'],
+            y=[0] * len(never_dl),
+            mode='markers',
+            name='Never Downloaded',
+            marker=dict(
+                size=never_dl['size_gb'].clip(lower=0.5).apply(lambda s: min(5 + s * 0.3, 25)),
+                color=ORANGE,
+                opacity=0.7,
+                symbol='circle-open',
+                line=dict(width=1.5, color=ORANGE)
+            ),
+            customdata=never_dl[['short_name', 'size_gb']].values,
+            hovertemplate=(
+                '<b>%{customdata[0]}</b><br>'
+                'Upload age: %{x:.1f} yr<br>'
+                'Never downloaded<br>'
+                'Size: %{customdata[1]:.2f} GB<extra></extra>'
+            )
+        ))
+
+    fig.update_layout(
+        title='File Lifecycle: Upload Age vs. Download Recency<br>'
+              f'<sub>Files ≥10 MB · Marker size ∝ file size · Vertical = {upload_threshold:.0f}-yr upload threshold · Horizontal = {download_threshold:.0f}-yr download threshold</sub>',
+        xaxis_title='Years Since Upload',
+        yaxis_title='Years Since Last Download (0 = never downloaded)',
+        width=width,
+        height=height,
+        legend=dict(x=1.02, y=1),
+        plot_bgcolor='white',
+        paper_bgcolor='white',
+    )
+    fig.update_xaxes(showgrid=True, gridcolor='rgba(128,128,128,0.2)', zeroline=False)
+    fig.update_yaxes(showgrid=True, gridcolor='rgba(128,128,128,0.2)', zeroline=False, rangemode='tozero')
+
+    return fig
+
+
+def _eol_scatter_base(x, y, color, symbol, hover_customdata, hovertemplate, name, title, xaxis_title, width, height):
+    """Shared layout helper for EOL candidate scatter plots."""
+    fig = go.Figure()
+    marker = dict(color=color, size=6, opacity=0.6)
+    if symbol == 'circle-open':
+        marker.update(symbol='circle-open', line=dict(width=1.5, color=color))
+    fig.add_trace(go.Scatter(
+        x=x, y=y, mode='markers', name=name,
+        marker=marker,
+        customdata=hover_customdata,
+        hovertemplate=hovertemplate,
+    ))
+    fig.update_layout(
+        title=title,
+        xaxis_title=xaxis_title,
+        yaxis_title='File Size (GB)',
+        yaxis_type='log',
+        width=width,
+        height=height,
+        showlegend=False,
+        plot_bgcolor='white',
+        paper_bgcolor='white',
+    )
+    fig.update_xaxes(showgrid=True, gridcolor='rgba(128,128,128,0.2)', zeroline=False)
+    fig.update_yaxes(showgrid=True, gridcolor='rgba(128,128,128,0.2)', zeroline=False)
+    return fig
+
+
+def plot_eol_never_downloaded(df, width=1400, height=600):
+    """Scatter of deletion candidates that were never downloaded.
+
+    x = upload date, y = file size (log scale).
+    """
+    if df.empty:
+        return go.Figure()
+
+    df = df[df['CONTENT_SIZE'] >= 10 * 1024 * 1024].copy()
+    if df.empty:
+        return go.Figure()
+
+    label_col = 'PROJECT_NAME' if 'PROJECT_NAME' in df.columns else 'PROJECT_ID'
+    df['size_gb'] = df['CONTENT_SIZE'] / 1e9
+    df['short_name'] = df[label_col].apply(
+        lambda x: ' '.join(str(x).split()[:4]) + ('…' if len(str(x).split()) > 4 else '')
+    )
+
+    return _eol_scatter_base(
+        x=pd.to_datetime(df['UPLOAD_DATE']),
+        y=df['size_gb'],
+        color=ORANGE,
+        symbol='circle-open',
+        hover_customdata=df[['short_name', 'size_gb']].values,
+        hovertemplate=(
+            '<b>%{customdata[0]}</b><br>'
+            'Upload date: %{x|%Y-%m-%d}<br>'
+            'Size: %{customdata[1]:.2f} GB<extra></extra>'
+        ),
+        name='Never Downloaded',
+        title='Deletion Candidates: Never Downloaded — Upload Date vs. File Size<br><sub>Files ≥10 MB</sub>',
+        xaxis_title='Upload Date',
+        width=width,
+        height=height,
+    )
+
+
+def plot_eol_stale_downloads(df, width=1400, height=600):
+    """Scatter of deletion candidates that were downloaded but are now stale.
+
+    x = last download date, y = file size (log scale).
+    """
+    if df.empty:
+        return go.Figure()
+
+    df = df[df['CONTENT_SIZE'] >= 10 * 1024 * 1024].copy()
+    if df.empty:
+        return go.Figure()
+
+    label_col = 'PROJECT_NAME' if 'PROJECT_NAME' in df.columns else 'PROJECT_ID'
+    df['size_gb'] = df['CONTENT_SIZE'] / 1e9
+    df['short_name'] = df[label_col].apply(
+        lambda x: ' '.join(str(x).split()[:4]) + ('…' if len(str(x).split()) > 4 else '')
+    )
+
+    return _eol_scatter_base(
+        x=pd.to_datetime(df['LAST_DOWNLOAD_DATE']),
+        y=df['size_gb'],
+        color=PORTAL_BLUE,
+        symbol='circle',
+        hover_customdata=df[['short_name', 'DOWNLOAD_COUNT', 'size_gb']].values,
+        hovertemplate=(
+            '<b>%{customdata[0]}</b><br>'
+            'Last download: %{x|%Y-%m-%d}<br>'
+            'Size: %{customdata[2]:.2f} GB<br>'
+            'Total downloads: %{customdata[1]:,}<extra></extra>'
+        ),
+        name='Stale Downloads',
+        title='Deletion Candidates: Stale Downloads — Last Download Date vs. File Size<br><sub>Files ≥10 MB</sub>',
+        xaxis_title='Last Download Date',
+        width=width,
+        height=height,
+    )
+
+
+def plot_s3_tier_estimate(df, width=700, height=500):
+    """Donut chart of estimated S3 Intelligent Tiering storage distribution.
+
+    Expects a pre-aggregated DataFrame with columns TIER and SIZE_TB,
+    as returned by query_s3_tier_all_portal().
+
+    Args:
+        df: DataFrame with columns TIER, SIZE_TB
+    """
+    if df.empty:
+        return go.Figure()
+
+    tier_order = ['Frequent Access', 'Infrequent Access', 'Archive Access', 'Deep Archive Access']
+    tier_colors = {
+        'Frequent Access':     '#125E81',
+        'Infrequent Access':   '#748dcd',
+        'Archive Access':      '#bc590b',
+        'Deep Archive Access': '#941E24',
+    }
+
+    df = df.set_index('TIER').reindex(tier_order).fillna(0).reset_index()
+
+    fig = go.Figure(go.Pie(
+        labels=df['TIER'],
+        values=df['SIZE_TB'],
+        hole=0.45,
+        marker=dict(colors=[tier_colors[t] for t in df['TIER']]),
+        textinfo='label+percent',
+        hovertemplate='<b>%{label}</b><br>%{value:.2f} TB<br>%{percent}<extra></extra>',
+        sort=False,
+    ))
+
+    total_tb = df['SIZE_TB'].sum()
+    fig.update_layout(
+        title=dict(
+            text=f'Estimated S3 Intelligent Tiering Distribution — All NF Portal Data ({total_tb:.1f} TB)<br>'
+                 '<sub>Based on days since last external download · Never-downloaded files use upload age as proxy · Estimated, not measured from S3</sub>',
+            x=0.5,
+        ),
+        width=width,
+        height=height,
+        legend=dict(orientation='v', x=1.02, y=0.5),
+        margin=dict(t=110, b=40, l=40, r=40),
+    )
+
+    return fig
+
+


### PR DESCRIPTION
## Summary

Supports the NF Data Portal Data End-of-Life Plan (proposal v0.1, staged for stakeholder review) and NTAP Task 2.9 ("co-develop and maintain data end-of-life plan"). Scoped entirely to `sage/nf/streamlit/nf_usage_metrics/` — no other funder's dashboard in this repo is touched.

Splits the existing single-page dashboard into two tabs:
- **📊 Data Analytics** — all existing content, unchanged, just moved inside a tab.
- **⏳ Data Lifecycle** — new: EOL candidate identification and S3 storage-tier estimates.

## What's in the Data Lifecycle tab

- **Estimated S3 Intelligent Tiering Distribution** — donut chart of all portal storage by tier (Frequent ≤30d / Infrequent 31–90d / Archive 91–180d / Deep Archive >180d since last access), independent of sidebar filters.
- For released projects (Available/Partially Available/Rolling Release) in the current selection:
  - A data caveat: Snowflake download records only go back to 2022-01-01, so pre-2022 files with no record may have been downloaded before that date.
  - Key metrics: total unique files, files with no download record (post-2022 uploads only), deletion-candidate count, deletion-candidate storage (TB).
  - Deletion-candidate scatter plots, split into never-downloaded vs. stale-downloads.
  - Upload age vs. download recency scatter with EOL threshold lines.
  - Per-project storage bar chart (downloaded vs. never-downloaded).

## New code

- `toolkit/queries.py`: `query_s3_tier_all_portal()`, `query_deep_archive_examples()`, `query_file_eol_analysis()`, `query_table_query_counts()`.
- `toolkit/widgets.py`: `plot_s3_tier_estimate()`, `plot_eol_scatter()`, `plot_eol_never_downloaded()`, `plot_eol_stale_downloads()`, `plot_never_downloaded_by_project()`, plus `plot_upload_age_histogram()`/`plot_download_recency_histogram()` helpers.

## Context

Ported from `nf-osi/snowflake-streamlit` PR #52 (open, never reviewed there) before that repo is archived. This app's existing content already went further than the old repo's `app.py` (an extra "Initiative Data Metrics" section) — preserved unchanged inside the new "Data Analytics" tab; only the wrapping tab structure is new.

Companion PR for the other piece of NTAP's Task 2.4 feedback (size distribution + user demographics): #392

Opened as a draft since it's an unreviewed cross-team port and a real structural change (existing page → tabs) — happy to adjust to match this app's conventions.

## Test plan

- [ ] Run the app locally and confirm both tabs render without errors
- [ ] Confirm all existing "Data Analytics" tab content is unchanged from before this PR
- [ ] Confirm the S3 tier donut total is plausible for current portal storage
- [ ] Confirm deletion-candidate metrics are plausible (files uploaded >10yr, no download or stale >5yr)
- [ ] Verify the data caveat banner is visible and accurate
- [ ] Confirm EOL analysis scopes only to released projects
- [ ] Verify the S3 tier query is independent of sidebar project/status filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)