### PR TITLE
[SNOW-542] Wrap int_synapse_data_access_submission_enriched ref in DYNAMIC_TABLE_REFRESH_BOUNDARY

### DIFF
--- a/.github/workflows/test_with_clone.yaml
+++ b/.github/workflows/test_with_clone.yaml
@@ -207,9 +207,6 @@ jobs:
             - name: Run dbt models on the clone
               working-directory: transform
               shell: bash
-              # --full-refresh forces CREATE OR REPLACE for dynamic tables cloned from the source
-              # database; without it, dbt only diffs warehouse/target_lag/refresh_mode and silently
-              # ALTERs pre-existing dynamic tables instead of applying SQL changes made in the PR.
               run: dbt run --selector synapse_data_warehouse --target clone --full-refresh
 
     drop_clone:

--- a/.github/workflows/test_with_clone.yaml
+++ b/.github/workflows/test_with_clone.yaml
@@ -207,7 +207,10 @@ jobs:
             - name: Run dbt models on the clone
               working-directory: transform
               shell: bash
-              run: dbt run --selector synapse_data_warehouse --target clone
+              # --full-refresh forces CREATE OR REPLACE for dynamic tables cloned from the source
+              # database; without it, dbt only diffs warehouse/target_lag/refresh_mode and silently
+              # ALTERs pre-existing dynamic tables instead of applying SQL changes made in the PR.
+              run: dbt run --selector synapse_data_warehouse --target clone --full-refresh
 
     drop_clone:
       runs-on: ubuntu-latest

--- a/transform/models/marts/synapse_data_warehouse/data_access_submission_event.sql
+++ b/transform/models/marts/synapse_data_warehouse/data_access_submission_event.sql
@@ -16,4 +16,4 @@ select
     accessor_changes,
     data_access_submission_raw
 from
-    {{ ref('int_synapse_data_access_submission_enriched') }}
+    dynamic_table_refresh_boundary({{ ref('int_synapse_data_access_submission_enriched') }})


### PR DESCRIPTION
# Problem
`SYNAPSE_DATA_WAREHOUSE.SYNAPSE_EVENT.DATA_ACCESS_SUBMISSION_EVENT` fails to refresh with:

> Dynamic Tables do not support reading from views containing objects of type DYNAMIC_TABLE

`data_access_submission_event` (dynamic table) selects from `int_synapse_data_access_submission_enriched`, a dbt intermediate view that transitively queries several `RDS_RAW` dynamic tables (`principal_alias`, `data_access_submission`, etc.).

Ticket: [SNOW-542](https://sagebionetworks.jira.com/browse/SNOW-542)

# Solution
Wrap the `{{ ref('int_synapse_data_access_submission_enriched') }}` reference in `dynamic_table_refresh_boundary(...)` in `transform/models/marts/synapse_data_warehouse/data_access_submission_event.sql`, marking the view dependency as an explicit refresh boundary rather than a hard pipeline dependency.

1. `DATA_ACCESS_SUBMISSION_EVENT` refreshes without error
    * Addressed in [transform/models/marts/synapse_data_warehouse/data_access_submission_event.sql](../blob/snow-542-dynamic-table-refresh-boundary-data-access-submission/transform/models/marts/synapse_data_warehouse/data_access_submission_event.sql)

# Testing
This PR is opened as a draft to trigger `test_with_clone.yaml`, which creates a `SYNAPSE_DATA_WAREHOUSE_DEV_{branch}` zero-copy clone and runs `dbt run --selector synapse_data_warehouse --target clone` against it. Verification: confirm `DATA_ACCESS_SUBMISSION_EVENT` in the clone refreshes successfully (no `DYNAMIC_TABLE` error) once the workflow completes.

[SNOW-542]: https://sagebionetworks.jira.com/browse/SNOW-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ