### PR TITLE
[SNOW-543] Grant RDS_RAW_TABLE_READ to RDS_RAW_ALL_ADMIN

### DIFF
--- a/synapse_data_warehouse/database_roles/V2.74.3__grant_rds_raw_table_read_to_all_admin.sql
+++ b/synapse_data_warehouse/database_roles/V2.74.3__grant_rds_raw_table_read_to_all_admin.sql
@@ -1,0 +1,8 @@
+USE DATABASE {{ database_name }}; --noqa: JJ01,PRS,TMP
+
+-- RDS_RAW_ALL_ADMIN owns the dbt-managed staging/intermediate views inside RDS_RAW, but
+-- dynamic tables in RDS_RAW are owned by the PROXY_ADMIN account role (Snowflake requires
+-- an account role to own dynamic tables), so schema ownership no longer gives
+-- RDS_RAW_ALL_ADMIN implicit read access to them.
+GRANT DATABASE ROLE RDS_RAW_TABLE_READ
+    TO DATABASE ROLE RDS_RAW_ALL_ADMIN;


### PR DESCRIPTION
# Problem

`SYNAPSE_DATA_WAREHOUSE_DEV.SYNAPSE_EVENT.DATA_ACCESS_SUBMISSION_EVENT` has failed every scheduled refresh since 2026-07-28 with:

```
Object 'SYNAPSE_DATA_WAREHOUSE_DEV.RDS_RAW.DATA_ACCESS_SUBMISSION' does not exist or not authorized.
```

Ticket: [SNOW-543](https://sagebionetworks.jira.com/browse/SNOW-543)

`RDS_RAW_ALL_ADMIN` owns the dbt-managed `STG_SYNAPSE__DATA_ACCESS_SUBMISSION` / `INT_SYNAPSE_DATA_ACCESS_SUBMISSION` views in `RDS_RAW`. SNOW-505 moved ownership of `RDS_RAW`'s dynamic tables (including `DATA_ACCESS_SUBMISSION`) to the `PROXY_ADMIN` account role, since Snowflake requires an account role to own dynamic tables. Standard Snowflake views resolve their FROM clause using the *view owner's* privileges at each hop, and `RDS_RAW_ALL_ADMIN` was never granted read access to the dynamic tables it no longer owns — confirmed live against `SYNAPSE_DATA_WAREHOUSE_DEV`:

- `RDS_RAW_ALL_ADMIN` owns both dbt views (`INFORMATION_SCHEMA.VIEWS.TABLE_OWNER` / `SHOW GRANTS TO DATABASE ROLE`).
- `RDS_RAW.DATA_ACCESS_SUBMISSION` (and its dynamic-table siblings) are owned by `PROXY_ADMIN`, not `RDS_RAW_ALL_ADMIN`.
- `RDS_RAW_ALL_ADMIN` **owns** the `RDS_RAW_TABLE_READ`/`RDS_RAW_TABLE_READ_MASKED` database roles (management rights only) but was never granted either — so it never inherited the SELECT/MONITOR privilege on RDS_RAW dynamic tables those roles hold.
- `RDS_RAW_ALL_ADMIN` owns *every* dbt staging/intermediate view in `RDS_RAW`, so this is a general RBAC gap affecting every downstream dynamic table built through those views, not just this one table.

Separate root cause from SNOW-542 (the `dynamic_table_refresh_boundary` view-chaining limitation) — that ticket's distinct error signature ("views containing objects of type DYNAMIC_TABLE") has never appeared in this table's refresh history.

# Solution

1. `RDS_RAW_ALL_ADMIN` is missing read access to RDS_RAW dynamic tables it doesn't own.
    * Added `synapse_data_warehouse/database_roles/V2.74.3__grant_rds_raw_table_read_to_all_admin.sql`, granting the existing `RDS_RAW_TABLE_READ` database role (already inherited by `RDS_RAW_ALL_DEVELOPER`, `V2.67.1:48`) to `RDS_RAW_ALL_ADMIN`. Being an inheritance grant, it automatically covers all current and future RDS_RAW dynamic tables in both dev and prod, with no separate future/backfill grants needed.

Validated against the RBAC framework docs ([Managing Object Privileges](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4115366084), [Role and Privilege Management](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4076863503)): non-ownership read-type access to an object an admin role doesn't own is handled via the schema's `_TABLE_READ` role, same as for any other consumer — no other schema currently needs this because in every other schema `_ALL_ADMIN` still owns its tables directly.

# Testing

Ran the `test_with_clone` workflow on this PR (no `skip_cloning` label) and validated directly against the resulting sandbox clone (`SYNAPSE_DATA_WAREHOUSE_DEV_SNOW_543_RDS_RAW_ALL_ADMIN_TABLE_READ_GRANT`):

1. **Migration deploys correctly.** After the clone's `schemachange` step ran, `SHOW GRANTS TO DATABASE ROLE RDS_RAW_ALL_ADMIN` confirmed it now holds `USAGE` on `RDS_RAW_TABLE_READ` (previously only `OWNERSHIP`, i.e. management rights with no inherited privileges) — the new V2.74.3 script applies cleanly with no version-collision or templating issues.
2. **Attempted an end-to-end dynamic table refresh test** (temporarily revoking the new grant, forcing `ALTER DYNAMIC TABLE ... REFRESH` on `DATA_ACCESS_SUBMISSION_EVENT`, expecting the same "not authorized" error, then re-granting and expecting success). This surfaced a **pre-existing, unrelated limitation** of the clone environment: `GET_DDL` showed the cloned `DATA_ACCESS_SUBMISSION_EVENT` object still has its query text baked to the *original* `SYNAPSE_DATA_WAREHOUSE_DEV` database (dbt's dynamic-table materialization treats the compiled SQL as unchanged and skips a real rebuild, and `RDS_RAW.DATA_ACCESS_SUBMISSION` itself is a versioned schemachange object schemachange won't recreate since its cloned `CHANGE_HISTORY` already marks it applied). So refreshing this specific table in *any* clone fails on a stale cross-database reference regardless of this PR — not something this change can fix or that this environment can currently exercise end-to-end. Restored the grant immediately after this was discovered so the clone reflects the intended fixed state.
3. **Ruled out an interactive-query substitute test**: querying the `RDS_RAW_ALL_ADMIN`-owned views as `DATA_ENGINEER` succeeded even with the new grant revoked, because `DATA_ENGINEER` already has independent, legitimate read access to `RDS_RAW` dynamic tables via `RDS_RAW_ALL_DEVELOPER` → `RDS_RAW_TABLE_READ` (pre-existing, unrelated to this fix) and, in the clone, via the `<CLONE>_PROXY_ADMIN` role's direct ownership of those tables. Neither path exists for `RDS_RAW_ALL_ADMIN` itself in the real dev/prod databases, so this doesn't substitute as a valid test.

Given that, the strongest confirmation of the actual root cause and fix remains the live evidence gathered against the real `SYNAPSE_DATA_WAREHOUSE_DEV` account (see Problem section): `PROXY_ADMIN` already directly owns *both* `RDS_RAW.DATA_ACCESS_SUBMISSION` and `SYNAPSE_EVENT.DATA_ACCESS_SUBMISSION_EVENT`, yet the refresh still fails — which is only possible if Snowflake resolves each view hop using that specific view's own owner (`RDS_RAW_ALL_ADMIN`), not the top-level executing role, confirming `RDS_RAW_ALL_ADMIN`'s own grants are what's missing. This PR's clone run confirms the fix deploys as intended; the actual dynamic-table-refresh behavior can only be confirmed once merged and running against real dev.

# Manual step required after deploy

`DATA_ACCESS_SUBMISSION_EVENT` is currently **SUSPENDED** in `SYNAPSE_DATA_WAREHOUSE_DEV` (Snowflake auto-suspended it after repeated consecutive refresh failures, `last_suspended_on: 2026-07-29T17:51:37`). Deploying this grant will not automatically resume it. Once merged and deployed, someone with the appropriate role will need to run:

```sql
ALTER DYNAMIC TABLE SYNAPSE_DATA_WAREHOUSE_DEV.SYNAPSE_EVENT.DATA_ACCESS_SUBMISSION_EVENT RESUME;
```

(Re-confirmed right before writing this: `RDS_RAW_ALL_ADMIN` in the real `SYNAPSE_DATA_WAREHOUSE_DEV` still only has `OWNERSHIP` of `RDS_RAW_TABLE_READ`, not `USAGE` — the gap is still live pre-merge, consistent with the root cause above.)

[SNOW-543]: https://sagebionetworks.jira.com/browse/SNOW-543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
