### PR TITLE
[SNOW-544] Fix dbt database resolution and dynamic table refresh boundary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,11 @@ jobs:
           ACCOUNT: ${{ secrets.SNOWSQL_ACCOUNT }}
           USER: ${{ vars.ADMIN_SERVICE_USER }}
           ROLE: sage_admin
-          DATABASE: SAGE
+          # marts/sage models explicitly override +database: SAGE in
+          # dbt_project.yml, so the default database here only needs to
+          # resolve refs into staging/intermediate synapse models, which
+          # live in SYNAPSE_DATA_WAREHOUSE.
+          DATABASE: ${{ vars.SNOWFLAKE_SYNAPSE_DATA_WAREHOUSE_DATABASE }}
           TARGET_NAME: prod
 
       - name: Run dbt models

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,10 +146,8 @@ jobs:
           ACCOUNT: ${{ secrets.SNOWSQL_ACCOUNT }}
           USER: ${{ vars.ADMIN_SERVICE_USER }}
           ROLE: sage_admin
-          # marts/sage models explicitly override +database: SAGE in
-          # dbt_project.yml, so the default database here only needs to
-          # resolve refs into staging/intermediate synapse models, which
-          # live in SYNAPSE_DATA_WAREHOUSE.
+          # Resolve refs for staging/intermediate models,
+          # which live in a SYNAPSE_DATA_WAREHOUSE environment.
           DATABASE: ${{ vars.SNOWFLAKE_SYNAPSE_DATA_WAREHOUSE_DATABASE }}
           TARGET_NAME: prod
 

--- a/transform/models/marts/sage/data_access_submission_dashboard.sql
+++ b/transform/models/marts/sage/data_access_submission_dashboard.sql
@@ -17,32 +17,32 @@ WITH base AS (
         state_reason,
         accessor_changes,
         data_access_submission_raw
-    FROM {{ ref('int_synapse_data_access_submission_enriched') }}
+    FROM dynamic_table_refresh_boundary({{ ref('int_synapse_data_access_submission_enriched') }})
 ),
 access_requirements AS (
     SELECT DISTINCT
         access_requirement_id,
         access_requirement_name
-    FROM {{ ref('int_synapse_access_requirement') }}
+    FROM dynamic_table_refresh_boundary({{ ref('int_synapse_access_requirement') }})
 ),
 approval_cycles AS (
     SELECT
         data_access_submission_id,
         COALESCE(
-            SUM(CASE WHEN state = 'Approved' THEN 1 ELSE 0 END) 
+            SUM(CASE WHEN state = 'Approved' THEN 1 ELSE 0 END)
                 OVER (PARTITION BY data_access_request_id ORDER BY created_on ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING),
             0
         ) AS approval_cycle
-    FROM {{ ref('int_synapse_data_access_submission_enriched') }}
+    FROM dynamic_table_refresh_boundary({{ ref('int_synapse_data_access_submission_enriched') }})
 ),
 attempts AS (
     SELECT
         enriched.data_access_submission_id,
         ROW_NUMBER() OVER (
-            PARTITION BY enriched.data_access_request_id, approval_cycles.approval_cycle 
+            PARTITION BY enriched.data_access_request_id, approval_cycles.approval_cycle
             ORDER BY enriched.created_on
         ) AS attempt
-    FROM {{ ref('int_synapse_data_access_submission_enriched') }} enriched
+    FROM dynamic_table_refresh_boundary({{ ref('int_synapse_data_access_submission_enriched') }}) enriched
     INNER JOIN approval_cycles 
         ON enriched.data_access_submission_id = approval_cycles.data_access_submission_id
 )


### PR DESCRIPTION
# Problem
The `schemachange_sage` CI job's `Run dbt models` step fails on `main`:

```
Database Error in model data_access_submission_dashboard (models/marts/sage/data_access_submission_dashboard.sql)
002003 (02000): SQL compilation error:
Schema 'SAGE.RDS_RAW' does not exist or not authorized.
```
Run: https://github.com/Sage-Bionetworks/snowflake/actions/runs/30661534943/job/91258878835

Two separate bugs cause this:
1. `staging.synapse`/`intermediate.synapse` models have no explicit `+database` override in `dbt_project.yml`, so they resolve against the connection's default database, which was set to `SAGE` in this case, so `ref('int_synapse_data_access_submission_enriched')` compiled to `SAGE.rds_raw...` instead of `SYNAPSE_DATA_WAREHOUSE.rds_raw...`. 
    + This bug has existed since the model was authored ([SNOW-407](https://sagebionetworks.jira.com/browse/SNOW-407)), but was masked because dbt only recreates an unchanged dynamic table on `--full-refresh` or a config change — which the recent full-refresh hotfix now forces.
2. The same bug we fixed in #400, except for the `data_access_submission_dashboard` model, which we materialize as a dynamic table in the `SAGE.GOVERNANCE` schema.

Ticket: [SNOW-544](https://sagebionetworks.jira.com/browse/SNOW-544)

# Solution
1. `data_access_submission_dashboard` refreshes without the `SAGE.RDS_RAW does not exist` error.
    * Updated the default database used in the dbt profile. Since our `marts.sage` models explicitly override `+database: SAGE`, we only need to specify the "default" database for our dbt models, which is a SYNAPSE_DATA_WAREHOUSE environment. In practice, this means the SYNAPSE_DATA_WAREHOUSE _database_, since we only deploy `marts.sage` models in production.
2. `data_access_submission_dashboard` refreshes without the "Dynamic Tables do not support reading from views containing objects of type DYNAMIC_TABLE" error.
    * Wrapped all four refs in [transform/models/marts/sage/data_access_submission_dashboard.sql](../blob/snow-544-fix-sage-dashboard-refresh/transform/models/marts/sage/data_access_submission_dashboard.sql) in `dynamic_table_refresh_boundary(...)`, matching the SNOW-542 precedent.

# Testing
- `dbt parse` and `dbt compile --select data_access_submission_dashboard` succeed locally with no new errors, and the compiled SQL correctly resolves refs and preserves the `dynamic_table_refresh_boundary(...)` wrap.
- This PR is opened as a draft; `test_with_clone.yaml` only exercises the `synapse_data_warehouse` selector against the clone, not `sage`, so full end-to-end verification requires merging this PR, then confirming `schemachange_sage` succeeds on the next `main` deploy.

[SNOW-407]: https://sagebionetworks.jira.com/browse/SNOW-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-542]: https://sagebionetworks.jira.com/browse/SNOW-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNOW-544]: https://sagebionetworks.jira.com/browse/SNOW-544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ